### PR TITLE
drop requirement for spaces before strings

### DIFF
--- a/shakespeare/Text/Shakespeare/Base.hs
+++ b/shakespeare/Text/Shakespeare/Base.hs
@@ -80,7 +80,7 @@ parseDeref = do
     return res
   where
     delim = (many1 (char ' ') >> return())
-            <|> lookAhead (char '(' >> return ())
+            <|> lookAhead (oneOf "(\"" >> return ())
     derefOp = try $ do
         _ <- char '('
         x <- many1 $ noneOf " \t\n\r()"


### PR DESCRIPTION
For example, this lets me do _{F"Bonjour"} instead of _{F "Bonjour"}
