### PR TITLE
perform coffeescript conversion at compile time

### DIFF
--- a/shakespeare-i18n/shakespeare-i18n.cabal
+++ b/shakespeare-i18n/shakespeare-i18n.cabal
@@ -6,7 +6,7 @@ author:          Michael Snoyman <michael@snoyman.com>
 maintainer:      Michael Snoyman <michael@snoyman.com>
 synopsis:        A type-based approach to internationalization.
 description:
-    This package uses the same approach of type-safe URLs to create translated content. It has a simple syntax for translators, while allowing the ful power of Haskell for applying complex grammar rules.
+    This package uses a compile-time, type-safe approach to create translated content. It has a simple syntax for translators, while allowing the full power of Haskell for applying complex grammar rules.
     .
     This package was spun off from yesod-core, and therefore the Yesod documentation is a good place to start in understanding this package. Please see <http://www.yesodweb.com/book/i18n> for more information.
 

--- a/shakespeare-js/shakespeare-js.cabal
+++ b/shakespeare-js/shakespeare-js.cabal
@@ -1,5 +1,5 @@
 name:            shakespeare-js
-version:         0.10.4
+version:         0.11.0
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -29,15 +29,23 @@ homepage:        http://www.yesodweb.com/book/templates
 
 library
     build-depends:   base             >= 4       && < 5
-                   , shakespeare      >= 0.10    && < 0.11
+                   , shakespeare      >= 0.10.3  && < 0.11
                    , template-haskell
                    , text             >= 0.7     && < 0.12
-                   , process          >= 1.0     && < 1.2
 
     exposed-modules:
                      Text.Julius
                      Text.Coffee
     ghc-options:     -Wall
+
+    if flag(test_coffee)
+        cpp-options: -DTEST_COFFEE
+
+    if flag(test)
+        cpp-options: -DTEST
+
+flag test
+    default: False
 
 flag test_coffee
     description: render tests through coffeescript render function
@@ -47,17 +55,19 @@ flag test_coffee
 test-suite test
     if flag(test_coffee)
         cpp-options: -DTEST_COFFEE
+
     hs-source-dirs: test
     main-is: ../test.hs
     type: exitcode-stdio-1.0
 
     ghc-options:   -Wall
-    build-depends: shakespeare-js   >= 0.10    && < 0.11
-                 , shakespeare      >= 0.10    && < 0.11
+    build-depends: shakespeare-js   >= 0.11    && < 0.12
+                 , shakespeare      >= 0.10.3  && < 0.11
                  , base             >= 4       && < 5
                  , HUnit
                  , hspec            >= 0.8     && < 0.10
                  , text             >= 0.7     && < 0.12
+                 , template-haskell
 
 
 source-repository head

--- a/shakespeare-js/test.hs
+++ b/shakespeare-js/test.hs
@@ -1,5 +1,5 @@
-import Test.Hspec
+import Test.Hspec.Monadic
 import ShakespeareJsTest (specs)
 
 main :: IO ()
-main = hspecX $ descriptions [specs]
+main = hspecX specs

--- a/shakespeare-test/LICENSE
+++ b/shakespeare-test/LICENSE
@@ -1,0 +1,25 @@
+The following license covers this documentation, and the source code, except
+where otherwise indicated.
+
+Copyright 2009, Michael Snoyman. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/shakespeare-test/main.hs
+++ b/shakespeare-test/main.hs
@@ -1,0 +1,8 @@
+import Test.Hspec.Monadic
+import qualified ShakespeareJsTest
+import qualified ShakespeareBaseTest
+
+main :: IO ()
+main = hspecX $ do
+  ShakespeareJsTest.specs
+  ShakespeareBaseTest.specs

--- a/shakespeare-test/shakespeare
+++ b/shakespeare-test/shakespeare
@@ -1,0 +1,1 @@
+../shakespeare

--- a/shakespeare-test/shakespeare-js
+++ b/shakespeare-test/shakespeare-js
@@ -1,0 +1,1 @@
+../shakespeare-js

--- a/shakespeare-test/shakespeare-test.cabal
+++ b/shakespeare-test/shakespeare-test.cabal
@@ -1,0 +1,60 @@
+name:            shakespeare-test
+version:         0.1
+license:         BSD3
+license-file:    LICENSE
+author:          Michael Snoyman <michael@snoyman.com>
+maintainer:      Michael Snoyman <michael@snoyman.com>
+synopsis:        Tests for Shakespeare
+description:     Tests for Shakespeare
+category:        Web, Yesod
+stability:       Stable
+cabal-version:   >= 1.8
+build-type:      Simple
+homepage:        http://www.yesodweb.com/book/templates
+
+extra-source-files:
+  test/main.hs
+
+library
+    exposed-modules:
+                     Text.Shakespeare
+                     Text.Shakespeare.Base
+                     Text.Julius
+                     Text.Coffee
+
+    build-depends:   base             >= 4       && < 5
+                   , template-haskell
+                   , parsec           >= 2       && < 4
+                   , text             >= 0.7     && < 0.12
+                   , process          >= 1.0     && < 1.2
+
+    hs-source-dirs: ., shakespeare, shakespeare-js
+
+    ghc-options:   -Wall
+    cpp-options:   -DTEST
+
+flag test_coffee
+    description: render tests through coffeescript render function
+    -- cabal configure --enable-tests -ftest_coffee && cabal build && dist/build/test/test
+    default: False
+
+test-suite test
+    type:          exitcode-stdio-1.0
+    main-is:       main.hs
+    hs-source-dirs: ., shakespeare-js/test, shakespeare/test
+
+    build-depends:   base >= 4 && < 5
+                   , shakespeare-test
+                   , hspec
+                   , HUnit
+                   , text             >= 0.7     && < 0.12
+                   , template-haskell
+                   , parsec           >= 2       && < 4
+
+    if flag(test_coffee)
+        cpp-options: -DTEST_COFFEE
+
+
+source-repository head
+  type:     git
+  location: git://github.com/yesodweb/shakespeare-test.git

--- a/shakespeare-test/test/juliuses
+++ b/shakespeare-test/test/juliuses
@@ -1,0 +1,1 @@
+../shakespeare-js/test/juliuses

--- a/shakespeare/Text/Shakespeare/Base.hs
+++ b/shakespeare/Text/Shakespeare/Base.hs
@@ -187,19 +187,12 @@ flattenDeref _ = Nothing
 parseHash :: Parser (Either String Deref)
 parseHash = parseVar '#'
 
-parseVarString :: Char -> Parser String
-parseVarString c = do
-    _ <- char c
-    bracketed <- curlyBrackets
-    return $ c:bracketed
-
 curlyBrackets :: Parser String
 curlyBrackets = do
   _<- char '{'
   var <- many1 $ noneOf "}"
   _<- char '}'
   return $ ('{':var) ++ "}"
-
 
 parseVar :: Char -> Parser (Either String Deref)
 parseVar c = do
@@ -225,13 +218,27 @@ parseUrl c d = do
             return $ Right (deref, x))
                 <|> return (Left $ if x then [c, d] else [c]))
 
-parseUrlString :: Char -> Char -> Parser String
+parseInterpolatedString :: Char -> Parser (Either String String)
+parseInterpolatedString c = do
+    _ <- char c
+    (char '\\' >> return (Left ['\\', c])) <|> (do
+        bracketed <- curlyBrackets
+        return $ Right (c:bracketed)) <|> return (Left [c])
+
+parseVarString :: Char -> Parser (Either String String)
+parseVarString = parseInterpolatedString
+
+parseUrlString :: Char -> Char -> Parser (Either String String)
 parseUrlString c d = do
     _ <- char c
-    (char '\\' >> return [c, '\\']) <|> (do
-        x <- (char d  >> return [d]) <|> return []
-        bracketed <- curlyBrackets
-        return $ c:x ++ bracketed)
+    (char '\\' >> return (Left [c, '\\'])) <|> (do
+        ds <- (char d >> return [d]) <|> return []
+        (do bracketed <- curlyBrackets
+            return $ Right (c:ds ++ bracketed))
+                <|> return (Left (c:ds)))
+
+parseIntString :: Char -> Parser (Either String String)
+parseIntString = parseInterpolatedString
 
 parseCaret :: Parser (Either String Deref)
 parseCaret = parseInt '^'
@@ -242,13 +249,6 @@ parseInt c = do
     (char '\\' >> return (Left [c])) <|> (do
         deref <- derefCurlyBrackets
         return $ Right deref) <|> return (Left [c])
-
-parseIntString :: Char -> Parser String
-parseIntString c = do
-    _ <- char c
-    (char '\\' >> return [c, '\\']) <|> (do
-        bracketed <- curlyBrackets
-        return $ c:bracketed)
 
 parseUnder :: Parser (Either String Deref)
 parseUnder = do

--- a/shakespeare/shakespeare.cabal
+++ b/shakespeare/shakespeare.cabal
@@ -1,16 +1,19 @@
 name:            shakespeare
-version:         0.10.2
+version:         0.10.3
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
 maintainer:      Michael Snoyman <michael@snoyman.com>
 synopsis:        A toolkit for making compile-time interpolated templates
 description:
-    Shakespeare is a template family for type-safe, efficient templates with simple variable interpolation . Shakespeare templates can be used inline with a quasi-quoter or in an external file. Shakespeare interpolates variables according to the type being inserted.
+    Shakespeare is a family of type-safe, efficient template languages. Shakespeare templates are expanded at compile-time, ensuring that all interpolated variables are in scope. Variables are interpolated according to their type through a typeclass.
     .
-    Note there is no dependency on haskell-src-extras.
+    Shakespeare templates can be used inline with a quasi-quoter or in an external file.
     .
-    packages that use this: shakespeare-js, shakespeare-css, shakespeare-interpolated, hamlet, and xml-hamlet
+    Note there is no dependency on haskell-src-extras. Instead Shakespeare believes logic should stay out of templates and has its own minimal Haskell parser.
+    .
+    Packages that use this: shakespeare-js, shakespeare-css, shakespeare-text, hamlet, and xml-hamlet
+    .
     Please see the documentation at <http://docs.yesodweb.com/book/hamlet/> for more details.
 
 category:        Web, Yesod
@@ -24,10 +27,31 @@ library
                    , template-haskell
                    , parsec           >= 2       && < 4
                    , text             >= 0.7     && < 0.12
+                   , process          >= 1.0     && < 1.2
+
     exposed-modules: 
                      Text.Shakespeare
                      Text.Shakespeare.Base
     ghc-options:     -Wall
+
+    if flag(test)
+      cpp-options: -DTEST
+
+Flag test
+  default: False
+
+test-suite test
+    hs-source-dirs: test
+    main-is: ../test.hs
+    type: exitcode-stdio-1.0
+
+    ghc-options:   -Wall
+    build-depends: shakespeare      >= 0.10.3  && < 0.11
+                 , base             >= 4       && < 5
+                 , parsec           >= 2       && < 4
+                 , HUnit
+                 , hspec            >= 0.8     && < 0.10
+                 , text             >= 0.7     && < 0.12
 
 
 source-repository head

--- a/shakespeare/test.hs
+++ b/shakespeare/test.hs
@@ -1,0 +1,5 @@
+import Test.Hspec.Monadic
+import ShakespeareBaseTest (specs)
+
+main :: IO ()
+main = hspecX $ specs

--- a/shakespeare/test/ShakespeareBaseTest.hs
+++ b/shakespeare/test/ShakespeareBaseTest.hs
@@ -1,0 +1,53 @@
+module ShakespeareBaseTest (specs) where
+
+import Test.HUnit hiding (Test)
+import Test.Hspec.Monadic
+import Test.Hspec.HUnit ()
+
+import Text.ParserCombinators.Parsec (parse, ParseError, (<|>))
+import Text.Shakespeare.Base (parseVarString, parseUrlString, parseIntString)
+import Text.Shakespeare (preFilter, defaultShakespeareSettings, ShakespeareSettings(..), PreConvert(..), PreConversion(..))
+
+-- run :: Text.Parsec.Prim.Parsec Text.Parsec.Pos.SourceName () c -> Text.Parsec.Pos.SourceName -> c
+
+specs :: Specs
+specs = describe "shakespeare-js" $ do
+  it "parseStrings" $ do
+    Right "%{var}" @=?  run varString "%{var}"
+    Right "@{url}" @=?  run urlString "@{url}"
+    Right "^{int}" @=?  run intString "^{int}"
+    Right "@{url}" @=?  run (varString <|> urlString <|> intString) "@{url} #{var}"
+
+  it "preFilter off" $ do
+    str <- preFilter defaultShakespeareSettings template
+    str @=? template
+
+  it "preFilter on" $ do
+    str <- preFilter preConversionSettings template
+    "unchanged `#{var}` `@{url}` `^{int}`" @=? str
+
+  it "preFilter ignore quotes" $ do
+    str <- preFilter preConversionSettings templateQuote
+    "unchanged '#{var}' `@{url}` '^{int}'" @=? str
+
+  where
+    varString = parseVarString '%'
+    urlString = parseUrlString '@' '?'
+    intString = parseIntString '^'
+
+    preConversionSettings = defaultShakespeareSettings {
+      preConversion = Just PreConvert {
+          preConvert = Id
+        , preEscapeBegin = "`"
+        , preEscapeEnd = "`"
+        , preEscapeIgnore = "'\""
+        }
+    }
+    template  = "unchanged #{var} @{url} ^{int}"
+    templateQuote = "unchanged '#{var}' @{url} '^{int}'"
+
+    run parser str = eShowErrors $ parse parser str str
+
+    eShowErrors :: Either ParseError c -> c
+    eShowErrors = either (error . show) id
+


### PR DESCRIPTION
-- | The Coffeescript language compiles down to Javascript.
-- Previously we waited until the very end, at the rendering stage to perform this compilation.
-- Lets call is a post-conversion
-- This had the advantage that all Haskell values were inserted first:
-- for example a value could be inserted that Coffeescript would compile into Javascript.
-- While that is perhaps a safer approach, the advantage is not used in practice:
-- it was that way mainly for ease of implementation.
-- The down-side is the template must be compiled down to Javascript during every request.
-- If instead we do a pre-conversion to compile down to Javascript,
-- we only need to perform the compilation once.
-- During the pre-conversion we first modify all Haskell insertions
-- so that they will be ignored by the Coffeescript compiler (backticks).
-- So %{var} is change to `%{var}` using the preVar function.

The tests fail because I have a shim for the lift instance corresponding to my additions to the Shakespeare settings. The PreConvert settings are apropriately abstract now, but if need be they can be changed so there are no String -> String functions and instead just String settings. However, we still need a PreConvert function. We could just hard-code that into Shakespeare.js: let me know what approach is needed.
