### PR TITLE
added 'mkMessageFor'

### DIFF
--- a/shakespeare-i18n/Text/Shakespeare/I18N.hs
+++ b/shakespeare-i18n/Text/Shakespeare/I18N.hs
@@ -43,7 +43,7 @@ class RenderMessage master message where
                   -> Text
 
 instance RenderMessage master Text where
-    renderMessage _ _    = id
+    renderMessage _ _ = id
 
 type Lang = Text
 


### PR DESCRIPTION
I added the 'mkMessageFor' function which is similar to 'mkMessage' but allows you to add translations for datatypes that already exist.

mkMessage and mkMessageFor use a new utility function 'mkMessageCommon' which abstracts out the common aspects of their behavior.

mkMessageFor could also be renamed to 'mkAdditionalMessages' as ending in a preposition is a bit odd.
