### PR TITLE
Fix comment on 'lucius'

### DIFF
--- a/shakespeare-css/Text/Lucius.hs
+++ b/shakespeare-css/Text/Lucius.hs
@@ -35,7 +35,7 @@ import Data.Monoid (mconcat)
 
 -- |
 --
--- >>> renderLucius undefined [lucius|foo{bar:baz}|]
+-- >>> renderCss ([lucius|foo{bar:baz}|] undefined)
 -- "foo{bar:baz}"
 lucius :: QuasiQuoter
 lucius = QuasiQuoter { quoteExp = luciusFromString }


### PR DESCRIPTION
'renderLucius' doesn't seem to exist, and I'm guessing this is the appropriate way to use 'lucius'.
