### PR TITLE
make it possible to enable newlines in Hamlet templates, making debugging easier

### DIFF
--- a/hamlet/Text/Hamlet.hs
+++ b/hamlet/Text/Hamlet.hs
@@ -27,13 +27,15 @@ module Text.Hamlet
       -- * Type classes
     , ToAttributes (..)
       -- * Internal, for making more
-    , HamletSettings
+    , HamletSettings (..)
     , hamletWithSettings
     , hamletFileWithSettings
     , defaultHamletSettings
     , xhtmlHamletSettings
     , Env (..)
     , HamletRules (..)
+    , hamletRules
+    , htmlRules
     ) where
 
 import Text.Shakespeare.Base
@@ -211,6 +213,11 @@ htmlRules = do
 hamlet :: QuasiQuoter
 hamlet = hamletWithSettings hamletRules defaultHamletSettings
 
+-- | A variant which adds newlines to the output. Useful for debugging
+-- but may alter browser page layout.
+hamlet' :: QuasiQuoter
+hamlet' = hamletWithSettings hamletRules defaultHamletSettings{hamletNewlines=True}
+         
 xhamlet :: QuasiQuoter
 xhamlet = hamletWithSettings hamletRules xhtmlHamletSettings
 


### PR DESCRIPTION
HamletSettings constructors, and default settings and rules, are now
exposed so that hamlet users can turn on newlines for any of hamlet's
modes. Also hamletCloseNewline is now hamletNewlines and affects most
(open tag, close tag, and ordinary content) lines.

(Hi Michael. The settings and rules are described as "Internal" but they're exported... so now we export a few more, enough to change them. An alternative would be to provide debug variants of all the *hamlet functions. A third option would be to always render with newlines, IMHO that's actually the more useful default.)
