### PR TITLE
Add record wildcard patterns

### DIFF
--- a/hamlet/test/HamletTest.hs
+++ b/hamlet/test/HamletTest.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 module HamletTest (spec) where
 
+import HamletTestTypes (ARecord(..))
+
 import Test.HUnit hiding (Test)
 import Test.Hspec
 
@@ -76,6 +78,8 @@ spec = do
     it "hamlet tuple" caseTuple
     it "complex pattern" caseComplex
     it "record pattern" caseRecord
+    it "record wildcard pattern #1" caseRecordWildCard
+    it "record wildcard pattern #2" caseRecordWildCard1
 
 
 
@@ -945,13 +949,27 @@ caseComplex = do
         #{a} #{b} #{c} #{e} #{f} #{g}
     |]
 
-data ARecord = ARecCon { field1 :: Int, field2 :: Bool }
-
 caseRecord :: Assertion
 caseRecord = do
-  let z = ARecCon 10 True
+  let z = ARecord 10 True
   helper "10" [hamlet|
-    $with ARecCon { field1, field2 = True } <- z
+    $with ARecord { field1, field2 = True } <- z
+        #{field1}
+    |]
+
+caseRecordWildCard :: Assertion
+caseRecordWildCard = do
+  let z = ARecord 10 True
+  helper "10 True" [hamlet|
+    $with ARecord {..} <- z
+        #{field1} #{field2}
+    |]
+
+caseRecordWildCard1 :: Assertion
+caseRecordWildCard1 = do
+  let z = ARecord 10 True
+  helper "10" [hamlet|
+    $with ARecord {field2 = True, ..} <- z
         #{field1}
     |]
 

--- a/hamlet/test/HamletTestTypes.hs
+++ b/hamlet/test/HamletTestTypes.hs
@@ -1,0 +1,7 @@
+module HamletTestTypes where
+
+-- This record is defined outside of the HamletTest module
+-- because record wildcards use 'reify' and reify doesn't
+-- see types defined in the local module.
+
+data ARecord = ARecord { field1 :: Int, field2 :: Bool }


### PR DESCRIPTION
This implementation necessarily uses reify and:
-- Important note! reify will fail if the record type is defined in the
-- same module as the reify is used. This means quasi-quoted Hamlet
-- literals will not be able to use wildcards to match record types
-- defined in the same module.
