### PR TITLE
Increase version bounds for shakespeare-js

### DIFF
--- a/shakespeare-js/shakespeare-js.cabal
+++ b/shakespeare-js/shakespeare-js.cabal
@@ -31,7 +31,7 @@ homepage:        http://www.yesodweb.com/book/shakespearean-templates
 
 library
     build-depends:   base             >= 4       && < 5
-                   , shakespeare      >= 1.0.2   && < 1.1
+                   , shakespeare      >= 1.0.3   && < 1.1
                    , template-haskell
                    , text             >= 0.7
                    , aeson            >= 0.5


### PR DESCRIPTION
shakespeare-js 1.1.2 depends on shakespeare-1.0.3 because it uses e.g. wrapInsertionIndent in Text.Coffee. Raise version lower bound.
