### PR TITLE
only re-parse a file if its mtime changed

### DIFF
--- a/shakespeare-test/shakespeare-test.cabal
+++ b/shakespeare-test/shakespeare-test.cabal
@@ -24,6 +24,10 @@ library
                      Text.Roy
 
     build-depends:   base             >= 4       && < 5
+                   , time             >= 1
+                   , system-filepath  >= 0.4
+                   , system-fileio    >= 0.3
+                   , containers
                    , template-haskell
                    , parsec           >= 2       && < 4
                    , text             >= 0.7     && < 0.12
@@ -53,6 +57,10 @@ test-suite test
     hs-source-dirs: ., shakespeare-js/test, shakespeare/test
 
     build-depends:   base >= 4 && < 5
+                   , time             >= 1
+                   , system-filepath  >= 0.4
+                   , system-fileio    >= 0.3
+                   , containers
                    , shakespeare-test
                    , hspec
                    , HUnit

--- a/shakespeare/shakespeare.cabal
+++ b/shakespeare/shakespeare.cabal
@@ -24,6 +24,10 @@ homepage:        http://www.yesodweb.com/book/shakespearean-templates
 
 library
     build-depends:   base             >= 4       && < 5
+                   , time             >= 1
+                   , system-filepath  >= 0.4
+                   , system-fileio    >= 0.3
+                   , containers
                    , template-haskell
                    , parsec           >= 2       && < 4
                    , text             >= 0.7
@@ -51,8 +55,12 @@ test-suite test
 
     ghc-options:   -Wall
     build-depends: base             >= 4       && < 5
+                 , time             >= 1
+                 , system-filepath  >= 0.4
+                 , system-fileio    >= 0.3
+                 , containers
                  , parsec           >= 2       && < 4
-                 , hspec            >= 1.3
+                 , hspec            >= 1.5
                  , text             >= 0.7     && < 0.12
                  , process
                  , template-haskell


### PR DESCRIPTION
maintains a single IORef Map lookup of files to their mtime
I would have liked to have an IORef for each file instead,
but I didn't know how to pass an IORef into shakespeareRuntime
while in TH land.

Rather than using system-fileio,
I tried using the getModificationTime function in directory.
Unfortunately, the type changed between directory 1.1 & 1.2
Trying to use directory 1.2 caused major installation issues.
So using directory would probably require supporting both versions.
Using system-fileio made for a very simple installation.
