### PR TITLE
ensure that operator <> is defined when building with pre 4.5 base

### DIFF
--- a/shakespeare/Text/Shakespeare.hs
+++ b/shakespeare/Text/Shakespeare.hs
@@ -55,6 +55,12 @@ import qualified Data.Map as M
 import System.Process (readProcessWithExitCode)
 import System.Exit (ExitCode(..))
 
+#if !MIN_VERSION_base(4,5,0)
+(<>) :: Monoid m => m -> m -> m
+(<>) = mappend
+{-# INLINE (<>) #-}
+#endif
+
 -- | A parser with a user state of [String]
 type Parser = Parsec String [String]
 -- | run a parser with a user state of [String]


### PR DESCRIPTION
Data.Monoid added <> as an alias for mappend in base version 4.5.0.0, but earlier versions didn't have it.

This patch fixes issue https://github.com/yesodweb/shakespeare/issues/101.
