### PR TITLE
change of toBuilder type

### DIFF
--- a/shakespeare-js/Text/Julius.hs
+++ b/shakespeare-js/Text/Julius.hs
@@ -77,20 +77,20 @@ asJavascriptUrl = id
 
 -- | A typeclass for types that can be interpolated in CoffeeScript templates.
 class ToJavascript a where
-    toJavascript :: a -> Builder
+    toJavascript :: a -> Javascript
 #if 0
-instance ToJavascript [Char] where toJavascript = fromLazyText . TL.pack
-instance ToJavascript TS.Text where toJavascript = fromText
-instance ToJavascript TL.Text where toJavascript = fromLazyText
-instance ToJavascript Javascript where toJavascript = unJavascript
-instance ToJavascript Builder where toJavascript = id
+instance ToJavascript [Char] where toJavascript = Javascript . fromLazyText . TL.pack
+instance ToJavascript TS.Text where toJavascript = Javascript . fromText
+instance ToJavascript TL.Text where toJavascript = Javascript . fromLazyText
+instance ToJavascript Javascript where toJavascript = Javascript . unJavascript
+instance ToJavascript Builder where toJavascript = Javascript
 #endif
-instance ToJavascript Bool where toJavascript = fromText . TS.toLower . TS.pack . show
-instance ToJavascript Value where toJavascript = fromValue
+instance ToJavascript Bool where toJavascript = Javascript . fromText . TS.toLower . TS.pack . show
+instance ToJavascript Value where toJavascript = Javascript . fromValue
 
 newtype RawJavascript = RawJavascript Builder
 instance ToJavascript RawJavascript where
-    toJavascript (RawJavascript a) = a
+    toJavascript (RawJavascript a) = Javascript a
 
 class RawJS a where
     rawJS :: a -> RawJavascript
@@ -99,7 +99,7 @@ instance RawJS [Char] where rawJS = RawJavascript . fromLazyText . TL.pack
 instance RawJS TS.Text where rawJS = RawJavascript . fromText
 instance RawJS TL.Text where rawJS = RawJavascript . fromLazyText
 instance RawJS Builder where rawJS = RawJavascript
-instance RawJS Bool where rawJS = RawJavascript . toJavascript
+instance RawJS Bool where rawJS = RawJavascript . unJavascript . toJavascript
 
 javascriptSettings :: Q ShakespeareSettings
 javascriptSettings = do

--- a/shakespeare/Text/Shakespeare.hs
+++ b/shakespeare/Text/Shakespeare.hs
@@ -362,7 +362,7 @@ contentsToShakespeare rs a = do
             ts <- [|fromText . pack'|]
             return $ wrap rs `AppE` (ts `AppE` LitE (StringL s'))
         contentToBuilder _ (ContentVar d) =
-            return $ wrap rs `AppE` (toBuilder rs `AppE` derefToExp [] d)
+            return $ (toBuilder rs `AppE` derefToExp [] d)
         contentToBuilder r (ContentUrl d) = do
             ts <- [|fromText|]
             return $ wrap rs `AppE` (ts `AppE` (VarE r `AppE` derefToExp [] d `AppE` ListE []))
@@ -439,7 +439,8 @@ shakespeareFileReload settings fp = do
         return $ TupE [d', c' `AppE` derefToExp [] d]
       where
         c :: VarType -> Q Exp
-        c VTPlain = [|EPlain . $(return $ toBuilder settings)|]
+        c VTPlain = [|EPlain . $(return $
+          InfixE (Just $ unwrap settings) (VarE '(.)) (Just $ toBuilder settings))|]
         c VTUrl = [|EUrl|]
         c VTUrlParam = [|EUrlParam|]
         c VTMixin = [|\x -> EMixin $ \r -> $(return $ unwrap settings) $ x r|]

--- a/shakespeare/test/ShakespeareBaseTest.hs
+++ b/shakespeare/test/ShakespeareBaseTest.hs
@@ -8,7 +8,7 @@ import Text.ParserCombinators.Parsec (parse, ParseError, (<|>))
 import Text.Shakespeare.Base (parseVarString, parseUrlString, parseIntString)
 import Text.Shakespeare (preFilter, defaultShakespeareSettings, ShakespeareSettings(..), PreConvert(..), PreConversion(..))
 import Language.Haskell.TH.Syntax (Exp (VarE))
-import Data.Text.Lazy.Builder (fromString, toLazyText)
+import Data.Text.Lazy.Builder (fromString, toLazyText, fromLazyText)
 import Data.Text.Lazy (pack)
 
 -- run :: Text.Parsec.Prim.Parsec Text.Parsec.Pos.SourceName () c -> Text.Parsec.Pos.SourceName -> c
@@ -44,9 +44,9 @@ specs = describe "shakespeare-js" $ do
   it "reload" $ do
     let helper input = $(do
             shakespeareFileReload defaultShakespeareSettings
-                { toBuilder = VarE 'fromString
+                { toBuilder = VarE 'pack
                 , wrap = VarE 'toLazyText
-                , unwrap = VarE 'undefined
+                , unwrap = VarE 'fromLazyText
                 } "test/reload.txt") undefined
     helper "here1" `shouldBe` pack "here1\n"
     helper "here2" `shouldBe` pack "here2\n"


### PR DESCRIPTION
I noticed that all the datatypes using the simple Text.Shakespeare interface (Text and Javascript) have to have datatypes that are simply a wrapper around a Builder. To convert a value into Javascript, for instance, we need to use toBuilder, followed by wrap. If the conversion required the creation of something more than a Builder, we'd be screwed. A more flexible approach would be to have toBuilder convert directly into the target type. This would allow shakespeare to build any type that has a Monoid instance, not just wrappers over Builders. Only shakespeareFileReload requires a raw Builder value, and will not work with general Monoid types.
