### PR TITLE
Trivial instance of Text.Shakespeare.Text.ToText

### DIFF
--- a/shakespeare-text/Text/Shakespeare/Text.hs
+++ b/shakespeare-text/Text/Shakespeare/Text.hs
@@ -36,6 +36,7 @@ type TextUrl url = RenderUrl url -> Builder
 
 class ToText a where
     toText :: a -> Builder
+instance ToText Builder where toText = id
 instance ToText [Char ] where toText = fromLazyText . TL.pack
 instance ToText TS.Text where toText = fromText
 instance ToText TL.Text where toText = fromLazyText


### PR DESCRIPTION
I’ve been using a trivial orphan instance of `ToText` in some of my code to simplify a few things.  `ToText` is for turning things into `Builder`s, so it makes sense to `instance ToText Builder` with the identity function.

I believe this shouldn’t break anything except for others who may be defining the same instance as an orphan, but we get warnings for that anyways.
