### PR TITLE
Needs template-haskell >= 2.7 due to lookupValueName

### DIFF
--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -37,7 +37,7 @@ library
     build-depends:   base             >= 4       && < 5
                    , time             >= 1
                    , containers
-                   , template-haskell
+                   , template-haskell >= 2.7
                    , parsec           >= 2       && < 4
                    , text             >= 0.7
                    , process          >= 1.0
@@ -150,7 +150,7 @@ test-suite test
                  , hspec            == 2.*
                  , text             >= 0.7
                  , process
-                 , template-haskell
+                 , template-haskell >= 2.7
                  , ghc-prim
                  , HUnit
                  , bytestring


### PR DESCRIPTION
GHC 7.2 & 7.4 build error:

```
Text/Hamlet.hs:186:34: Not in scope: `lookupValueName'
```
