### PR TITLE
pull in Value -> Builder function

### DIFF
--- a/Text/Julius.hs
+++ b/Text/Julius.hs
@@ -130,6 +130,7 @@ string s = {-# SCC "string" #-} singleton '"' <> quote s <> singleton '"'
                  c == '\\' ||
                  c == '<'  ||
                  c == '>'  ||
+                 c == '&'  ||
                  c < '\x20'
     escape '\"' = "\\\""
     escape '\\' = "\\\\"
@@ -138,6 +139,7 @@ string s = {-# SCC "string" #-} singleton '"' <> quote s <> singleton '"'
     escape '\t' = "\\t"
     escape '<' = "\\u003c"
     escape '>' = "\\u003e"
+    escape '&' = "\\u0026"
 
     escape c
         | c < '\x20' = fromString $ "\\u" ++ replicate (4 - length h) '0' ++ h

--- a/Text/Julius.hs
+++ b/Text/Julius.hs
@@ -128,12 +128,16 @@ string s = {-# SCC "string" #-} singleton '"' <> quote s <> singleton '"'
         where (h,t) = {-# SCC "break" #-} T.break isEscape q
     isEscape c = c == '\"' ||
                  c == '\\' ||
+                 c == '<'  ||
+                 c == '>'  ||
                  c < '\x20'
     escape '\"' = "\\\""
     escape '\\' = "\\\\"
     escape '\n' = "\\n"
     escape '\r' = "\\r"
     escape '\t' = "\\t"
+    escape '<' = "\\u003c"
+    escape '>' = "\\u003e"
 
     escape c
         | c < '\x20' = fromString $ "\\u" ++ replicate (4 - length h) '0' ++ h

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -49,6 +49,9 @@ library
                    , blaze-html
                    , exceptions
                    , transformers
+                   , vector
+                   , unordered-containers
+                   , scientific
 
     exposed-modules: Text.Shakespeare.I18N
                      Text.Shakespeare.Text

--- a/test/Text/Shakespeare/JsSpec.hs
+++ b/test/Text/Shakespeare/JsSpec.hs
@@ -134,6 +134,8 @@ console.log roy
 
   it "> escaping" $ jelper "\"\\u003e\"" [julius|#{toJSON ">"}|]
 
+  it "& escaping" $ jelper "\"\\u0026\"" [julius|#{toJSON "&"}|]
+
   it "boolean interpolation" $ jelper
     "true false true false true false"
     [julius|#{True} #{False} #{toJSON True} #{toJSON False} #{rawJS True} #{rawJS False}|]

--- a/test/Text/Shakespeare/JsSpec.hs
+++ b/test/Text/Shakespeare/JsSpec.hs
@@ -130,6 +130,10 @@ console.log roy
 
   it "JSON data" $ jelper "\"Hello \\\"World!\\\"\"" [julius|#{toJSON "Hello \"World!\""}|]
 
+  it "< escaping" $ jelper "\"\\u003c\"" [julius|#{toJSON "<"}|]
+
+  it "> escaping" $ jelper "\"\\u003e\"" [julius|#{toJSON ">"}|]
+
   it "boolean interpolation" $ jelper
     "true false true false true false"
     [julius|#{True} #{False} #{toJSON True} #{toJSON False} #{rawJS True} #{rawJS False}|]


### PR DESCRIPTION
Context: https://groups.google.com/forum/#!topic/yesodweb/M2VS5OTwyPg

This pulls in and incorporates `encodeToTextBuilder` from Aeson, so that we can add web-specific escaping such as:

```
escape '<' = "\\u003c"
escape '>' = "\\u003e"
```
