### PR TITLE
Require scientific >= 0.3.0.0

### DIFF
--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -51,7 +51,7 @@ library
                    , transformers
                    , vector
                    , unordered-containers
-                   , scientific
+                   , scientific       >= 0.3.0.0
 
     exposed-modules: Text.Shakespeare.I18N
                      Text.Shakespeare.Text


### PR DESCRIPTION
Dependency lower bound required due to import of Data.Text.Lazy.Builder.Scientific in Text.Julius.