### PR TITLE
Make it work with ghc-8.0

### DIFF
--- a/Text/Hamlet.hs
+++ b/Text/Hamlet.hs
@@ -181,8 +181,13 @@ recordToFieldNames conStr = do
   -- use 'lookupValueName' instead of just using 'mkName' so we reify the
   -- data constructor and not the type constructor if their names match.
   Just conName                <- lookupValueName $ conToStr conStr
+#if MIN_VERSION_template_haskell(2,11,0)
+  DataConI _ _ typeName         <- reify conName
+  TyConI (DataD _ _ _ _ cons _) <- reify typeName
+#else
   DataConI _ _ typeName _     <- reify conName
   TyConI (DataD _ _ _ cons _) <- reify typeName
+#endif
   [fields] <- return [fields | RecC name fields <- cons, name == conName]
   return [fieldName | (fieldName, _, _) <- fields]
 

--- a/Text/Shakespeare/I18N.hs
+++ b/Text/Shakespeare/I18N.hs
@@ -170,8 +170,12 @@ mkMessageCommon genType prefix postfix master dt folder lang = do
     c2 <- mapM (sToClause prefix dt) sdef
     c3 <- defClause
     return $
-     ( if genType 
-       then ((DataD [] mname [] (map (toCon dt) sdef) []) :)
+     ( if genType
+       then ((DataD [] mname []
+#if MIN_VERSION_template_haskell(2,11,0)
+                    Nothing
+#endif
+                    (map (toCon dt) sdef) []) :)
        else id)
         [ InstanceD
             []
@@ -252,7 +256,7 @@ toCon :: String -> SDef -> Con
 toCon dt (SDef c vs _) =
     RecC (mkName $ "Msg" ++ c) $ map go vs
   where
-    go (n, t) = (varName dt n, NotStrict, ConT $ mkName t)
+    go (n, t) = (varName dt n, notStrict, ConT $ mkName t)
 
 varName :: String -> String -> Name
 varName a y =
@@ -402,3 +406,11 @@ instance IsString (SomeMessage master) where
 
 instance master ~ master' => RenderMessage master (SomeMessage master') where
     renderMessage a b (SomeMessage msg) = renderMessage a b msg
+
+#if MIN_VERSION_template_haskell(2,11,0)
+notStrict :: Bang
+notStrict = Bang NoSourceUnpackedness NoSourceStrictness
+#else
+notStrict :: Strict
+notStrict = NotStrict
+#endif


### PR DESCRIPTION
Use CPP hackery to make it compile with ghc-8.0 and ghc 7.10. If
ghc-7.10 works, I assume earlier supported versions of GHC also
work. All tests pass with both GHC versions.

No functional or API changes.