### PR TITLE
Markdown support (marcus)

### DIFF
--- a/Text/Css.hs
+++ b/Text/Css.hs
@@ -346,7 +346,7 @@ blockToMixin :: Name
              -> Scope
              -> Block Unresolved
              -> Q Exp
-blockToMixin r scope (Block _sel props subblocks mixins) =
+blockToMixin r scope (Block _sel props _subblocks mixins) =
     [|Mixin
         { mixinAttrs    = concat
                         $ $(listE $ map go props)
@@ -364,7 +364,7 @@ blockToMixin r scope (Block _sel props subblocks mixins) =
     go (Attr x y) = conE 'Attr
         `appE` (contentsToBuilder r scope x)
         `appE` (contentsToBuilder r scope y)
-    subGo (Block sel' b c d) = blockToCss r scope $ Block sel' b c d
+    -- subGo (Block sel' b c d) = blockToCss r scope $ Block sel' b c d
 
 blockToCss :: Name
            -> Scope

--- a/Text/Hamlet.hs
+++ b/Text/Hamlet.hs
@@ -465,17 +465,6 @@ xshamletFile = hamletFileWithSettings htmlRules xhtmlHamletSettings
 ihamletFile :: FilePath -> Q Exp
 ihamletFile = hamletFileWithSettings ihamletRules defaultHamletSettings
 
-varName :: Scope -> String -> Exp
-varName _ "" = error "Illegal empty varName"
-varName scope v@(_:_) = fromMaybe (strToExp v) $ lookup (Ident v) scope
-
-strToExp :: String -> Exp
-strToExp s@(c:_)
-    | all isDigit s = LitE $ IntegerL $ read s
-    | isUpper c = ConE $ mkName s
-    | otherwise = VarE $ mkName s
-strToExp "" = error "strToExp on empty string"
-
 -- | Checks for truth in the left value in each pair in the first argument. If
 -- a true exists, then the corresponding right action is performed. Only the
 -- first is performed. In there are no true values, then the second argument is
@@ -503,12 +492,12 @@ data VarExp msg url  = EPlain Html
                      | EMsg msg
 
 instance Show (VarExp msg url) where
-  show (EPlain html) = "EPlain"
-  show (EUrl url) = "EUrl"
-  show (EUrlParam url) = "EUrlParam"
-  show (EMixin url) = "EMixin"
-  show (EMixinI18n msg_url) = "EMixinI18n"
-  show (EMsg msg) = "EMsg"
+  show (EPlain _html) = "EPlain"
+  show (EUrl _url) = "EUrl"
+  show (EUrlParam _url) = "EUrlParam"
+  show (EMixin _url) = "EMixin"
+  show (EMixinI18n _msg_url) = "EMixinI18n"
+  show (EMsg _msg) = "EMsg"
 
 getVars :: Content -> [(Deref, VarType)]
 getVars ContentRaw{}     = []
@@ -552,7 +541,7 @@ hamletFileReloadWithSettings hrr settings fp = do
             c VTPlain = [|EPlain . toHtml|]
             c VTUrl = [|EUrl|]
             c VTUrlParam = [|EUrlParam|]
-            c VTMixin = [|\r -> EMixin $ \c -> r c|]
+            c VTMixin = [|\r -> EMixin $ \c' -> r c'|]
             c VTMsg = [|EMsg|]
 
 -- move to Shakespeare.Base?

--- a/Text/Hamlet/RT.hs
+++ b/Text/Hamlet/RT.hs
@@ -77,14 +77,14 @@ parseHamletRT set s =
         Error s' -> throwM $ HamletParseException s'
         Ok (_, x) -> liftM HamletRT $ mapM convert x
   where
-    convert x@(DocForall deref (BindAs _ _) docs) =
+    convert (DocForall _deref (BindAs _ _) _docs) =
        error "Runtime Hamlet does not currently support 'as' patterns"
     convert x@(DocForall deref (BindVar (Ident ident)) docs) = do
         deref' <- flattenDeref' x deref
         docs' <- mapM convert docs
         return $ SDForall deref' ident docs'
     convert DocForall{} = error "Runtime Hamlet does not currently support tuple patterns"
-    convert x@(DocMaybe deref (BindAs _ _) jdocs ndocs) =
+    convert (DocMaybe _deref (BindAs _ _) _jdocs _ndocs) =
        error "Runtime Hamlet does not currently support 'as' patterns"
     convert x@(DocMaybe deref (BindVar (Ident ident)) jdocs ndocs) = do
         deref' <- flattenDeref' x deref
@@ -114,7 +114,7 @@ parseHamletRT set s =
       where
         -- | See the comments in Text.Hamlet.Parse.testIncludeClazzes. The conditional
         -- added there doesn't work for runtime Hamlet, so we remove it here.
-        go (DerefBranch (DerefIdent x) _, docs') | x == specialOrIdent = do
+        go (DerefBranch (DerefIdent y) _, docs') | y == specialOrIdent = do
             docs'' <- mapM convert docs'
             return (["True"], docs'')
         go (deref, docs') = do

--- a/Text/Julius.hs
+++ b/Text/Julius.hs
@@ -172,11 +172,8 @@ javascriptSettings = do
   wrapExp <- [|Javascript|]
   unWrapExp <- [|unJavascript|]
   asJavascriptUrl' <- [|asJavascriptUrl|]
-  return $ defaultShakespeareSettings { toBuilder = toJExp
-  , wrap = wrapExp
-  , unwrap = unWrapExp
-  , modifyFinalValue = Just asJavascriptUrl'
-  }
+  return $ (defaultShakespeareSettings toJExp wrapExp unWrapExp)
+    { modifyFinalValue = Just asJavascriptUrl' }
 
 js, julius :: QuasiQuoter
 js = QuasiQuoter { quoteExp = \s -> do
@@ -210,4 +207,7 @@ jsFileDebug = jsFileReload
 -- | Determine which identifiers are used by the given template, useful for
 -- creating systems like yesod devel.
 juliusUsedIdentifiers :: String -> [(Deref, VarType)]
-juliusUsedIdentifiers = shakespeareUsedIdentifiers defaultShakespeareSettings
+juliusUsedIdentifiers = shakespeareUsedIdentifiers partialSettings
+  where
+    unused = error "Unused setting"
+    partialSettings = defaultShakespeareSettings unused unused unused

--- a/Text/Marcus.hs
+++ b/Text/Marcus.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -fno-warn-missing-fields #-}
+-- | A Shakespearean module for CoffeeScript, introducing type-safe,
+-- compile-time variable and url interpolation. It is exactly the same as
+-- "Text.Julius", except that the template is first compiled to Javascript with
+-- the system tool @coffee@.
+--
+-- To use this module, @coffee@ must be installed on your system.
+--
+-- @#{...}@ is the Shakespearean standard for variable interpolation, but
+-- CoffeeScript already uses that sequence for string interpolation. Therefore,
+-- Shakespearean interpolation is introduced with @%{...}@.
+--
+-- If you interpolate variables,
+-- the template is first wrapped with a function containing javascript variables representing shakespeare variables,
+-- then compiled with @coffee@,
+-- and then the value of the variables are applied to the function.
+-- This means that in production the template can be compiled
+-- once at compile time and there will be no dependency in your production
+-- system on @coffee@. 
+--
+-- Your code:
+--
+-- >   b = 1
+-- >   console.log(#{a} + b)
+--
+-- Function wrapper added to your coffeescript code:
+--
+-- > ((shakespeare_var_a) =>
+-- >   b = 1
+-- >   console.log(shakespeare_var_a + b)
+-- > )
+--
+-- This is then compiled down to javascript, and the variables are applied:
+--
+-- > ;(function(shakespeare_var_a){
+-- >   var b = 1;
+-- >   console.log(shakespeare_var_a + b);
+-- > })(#{a});
+--
+--
+-- Further reading:
+--
+-- 1. Shakespearean templates: <http://www.yesodweb.com/book/templates>
+--
+-- 2. CoffeeScript: <http://coffeescript.org/>
+module Text.Coffee
+    ( -- * Functions
+      -- ** Template-Reading Functions
+      -- | These QuasiQuoter and Template Haskell methods return values of
+      -- type @'JavascriptUrl' url@. See the Yesod book for details.
+      coffee
+    , coffeeFile
+    , coffeeFileReload
+    , coffeeFileDebug
+
+#ifdef TEST_EXPORT
+    , coffeeSettings
+#endif
+    ) where
+
+import Language.Haskell.TH.Quote (QuasiQuoter (..))
+import Language.Haskell.TH.Syntax
+import Text.Shakespeare
+import Text.Julius
+
+coffeeSettings :: Q ShakespeareSettings
+coffeeSettings = do
+  jsettings <- javascriptSettings
+  return $ jsettings { varChar = '%'
+  , preConversion = Just PreConvert {
+      preConvert = ReadProcess "coffee" ["-spb"]
+    , preEscapeIgnoreBalanced = "'\"`"     -- don't insert backtacks for variable already inside strings or backticks.
+    , preEscapeIgnoreLine = "#"            -- ignore commented lines
+    , wrapInsertion = Just WrapInsertion { 
+        wrapInsertionIndent = Just "  "
+      , wrapInsertionStartBegin = "("
+      , wrapInsertionSeparator = ", "
+      , wrapInsertionStartClose = ") =>"
+      , wrapInsertionEnd = ""
+      , wrapInsertionAddParens = False
+      }
+    }
+  }
+
+-- | Read inline, quasiquoted CoffeeScript.
+coffee :: QuasiQuoter
+coffee = QuasiQuoter { quoteExp = \s -> do
+    rs <- coffeeSettings
+    quoteExp (shakespeare rs) s
+    }
+
+-- | Read in a CoffeeScript template file. This function reads the file once, at
+-- compile time.
+coffeeFile :: FilePath -> Q Exp
+coffeeFile fp = do
+    rs <- coffeeSettings
+    shakespeareFile rs fp
+
+-- | Read in a CoffeeScript template file. This impure function uses
+-- unsafePerformIO to re-read the file on every call, allowing for rapid
+-- iteration.
+coffeeFileReload :: FilePath -> Q Exp
+coffeeFileReload fp = do
+    rs <- coffeeSettings
+    shakespeareFileReload rs fp
+
+-- | Deprecated synonym for 'coffeeFileReload'
+coffeeFileDebug :: FilePath -> Q Exp
+coffeeFileDebug = coffeeFileReload
+{-# DEPRECATED coffeeFileDebug "Please use coffeeFileReload instead." #-}

--- a/Text/Shakespeare.hs
+++ b/Text/Shakespeare.hs
@@ -143,11 +143,18 @@ data ShakespeareSettings = ShakespeareSettings
     -- meaningful error messages.
     }
 
-defaultShakespeareSettings :: ShakespeareSettings
-defaultShakespeareSettings = ShakespeareSettings {
+defaultShakespeareSettings
+    :: Exp -- ^ An Exp that will convert variables to 'Builder'
+    -> Exp -- ^ An Exp that converts 'Builder' to the type being generated
+    -> Exp -- ^ The reversal of the previous conversion argument
+    -> ShakespeareSettings
+defaultShakespeareSettings tobuild wrapexp unwrapexp = ShakespeareSettings {
     varChar = '#'
   , urlChar = '@'
   , intChar = '^'
+  , toBuilder = tobuild
+  , wrap = wrapexp
+  , unwrap = unwrapexp
   , justVarInterpolation = False
   , preConversion = Nothing
   , modifyFinalValue = Nothing

--- a/Text/Shakespeare.hs
+++ b/Text/Shakespeare.hs
@@ -125,8 +125,7 @@ data WrapInsertion = WrapInsertion {
 
 data PreConversion = ReadProcess String [String]
                    | Id
-  
-
+                   | ConvertAction (String -> String)
 
 data ShakespeareSettings = ShakespeareSettings
     { varChar :: Char
@@ -274,6 +273,7 @@ preFilter mfp ShakespeareSettings {..} template =
               withVars = (addVars mWrapI vars parsed)
           in  applyVars mWrapI vars `fmap` case convert of
                   Id -> return withVars
+                  ConvertAction act -> pure (act template)
                   ReadProcess command args ->
                     readProcessError command args withVars mfp
   where

--- a/Text/Shakespeare.hs
+++ b/Text/Shakespeare.hs
@@ -85,9 +85,9 @@ readFileUtf8 fp = fmap TL.unpack $ readUtf8File fp
 
 -- | Coffeescript, TypeScript, and other languages compiles down to Javascript.
 -- Previously we waited until the very end, at the rendering stage to perform this compilation.
--- Lets call is a post-conversion
+-- Lets call this a post-conversion.
 -- This had the advantage that all Haskell values were inserted first:
--- for example a value could be inserted that Coffeescript would compile into Javascript.
+-- For example a value could be inserted that Coffeescript would compile into Javascript.
 -- While that is perhaps a safer approach, the advantage is not used in practice:
 -- it was that way mainly for ease of implementation.
 -- The down-side is the template must be compiled down to Javascript during every request.
@@ -96,8 +96,8 @@ readFileUtf8 fp = fmap TL.unpack $ readUtf8File fp
 --
 -- The problem then is the insertion of Haskell values: we need a hole for
 -- them. This can be done with variables known to the language.
--- During the pre-conversion we first modify all Haskell insertions
--- So #{a} is change to shakespeare_var_a
+-- During the pre-conversion we first modify all Haskell insertions,
+-- so #{a} is changed to shakespeare_var_a
 -- Then we can place the Haskell values in a function wrapper that exposes
 -- those variables: (function(shakespeare_var_a){ ... shakespeare_var_a ...})
 -- TypeScript can compile that, and then we tack an application of the

--- a/Text/Shakespeare/Text.hs
+++ b/Text/Shakespeare/Text.hs
@@ -53,11 +53,7 @@ settings = do
   toTExp <- [|toText|]
   wrapExp <- [|id|]
   unWrapExp <- [|id|]
-  return $ defaultShakespeareSettings { toBuilder = toTExp
-  , wrap = wrapExp
-  , unwrap = unWrapExp
-  }
-
+  return $ defaultShakespeareSettings toTExp wrapExp unWrapExp
 
 stext, lt, st, text, lbt, sbt :: QuasiQuoter
 stext = 
@@ -126,14 +122,12 @@ codegenSettings = do
   toTExp <- [|toText|]
   wrapExp <- [|id|]
   unWrapExp <- [|id|]
-  return $ defaultShakespeareSettings { toBuilder = toTExp
-  , wrap = wrapExp
-  , unwrap = unWrapExp
-  , varChar = '~'
-  , urlChar = '*'
-  , intChar = '&'
-  , justVarInterpolation = True -- always!
-  }
+  return $ (defaultShakespeareSettings toTExp wrapExp unWrapExp)
+    { varChar = '~'
+    , urlChar = '*'
+    , intChar = '&'
+    , justVarInterpolation = True -- always!
+    }
 
 -- | codegen is designed for generating Yesod code, including templates
 -- So it uses different interpolation characters that won't clash with templates.

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -66,6 +66,7 @@ library
                      Text.Shakespeare.Base
                      Text.Shakespeare
                      Text.TypeScript
+                     Text.Marcus
     other-modules:   Text.Hamlet.Parse
                      Text.Css
                      Text.MkSizeType

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -117,8 +117,10 @@ test-suite test
                     Text.CssSpec
                     Text.HamletSpec
                     Text.JuliusSpec
+                    Text.MarcusSpec
                     Quoter
                     HamletTestTypes
+                    TestUrl
 
     cpp-options: -DTEST_EXPORT
 

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -52,6 +52,7 @@ library
                    , vector
                    , unordered-containers
                    , scientific       >= 0.3.0.0
+                   , markdown
 
     exposed-modules: Text.Shakespeare.I18N
                      Text.Shakespeare.Text

--- a/test/TestUrl.hs
+++ b/test/TestUrl.hs
@@ -1,0 +1,50 @@
+-- | Provide some urls for testing interpolation
+module TestUrl where
+
+import Data.List (intercalate)
+import Data.Text (Text, pack, unpack)
+
+-- * For testing @{}, here are some dummy routes and their rendering
+
+data Url = Home | Sub SubUrl
+data SubUrl = SubUrl
+
+-- * Render them
+
+renderUrl :: Url -> [(Text, Text)] -> Text
+renderUrl Home qs = pack "url" `mappend` showParams qs
+renderUrl (Sub SubUrl) qs = pack "suburl" `mappend` showParams qs
+
+-- * Subfunctions
+
+showParams :: [(Text, Text)] -> Text
+showParams [] = pack ""
+showParams z =
+    pack $ '?' : intercalate "&" (map go z)
+  where
+    go (x, y) = go' x ++ '=' : go' y
+    go' = concatMap encodeUrlChar . unpack
+
+-- | Taken straight from web-encodings; reimplemented here to avoid extra
+-- dependencies.
+encodeUrlChar :: Char -> String
+encodeUrlChar c
+    -- List of unreserved characters per RFC 3986
+    -- Gleaned from http://en.wikipedia.org/wiki/Percent-encoding
+    | 'A' <= c && c <= 'Z' = [c]
+    | 'a' <= c && c <= 'z' = [c]
+    | '0' <= c && c <= '9' = [c]
+encodeUrlChar c@'-' = [c]
+encodeUrlChar c@'_' = [c]
+encodeUrlChar c@'.' = [c]
+encodeUrlChar c@'~' = [c]
+encodeUrlChar ' ' = "+"
+encodeUrlChar y =
+    let (a, c) = fromEnum y `divMod` 16
+        b = a `mod` 16
+        showHex' x
+            | x < 10 = toEnum $ x + (fromEnum '0')
+            | x < 16 = toEnum $ x - 10 + (fromEnum 'A')
+            | otherwise = error $ "Invalid argument to showHex: " ++ show x
+     in ['%', showHex' b, showHex' c]
+

--- a/test/Text/MarcusSpec.hs
+++ b/test/Text/MarcusSpec.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Text.MarcusSpec (spec) where
+
+import Data.Text.Lazy.Builder
+import Test.Hspec
+import Data.Text (Text)
+import qualified Data.Text.Lazy as LT
+
+import TestUrl
+import Text.Marcus
+
+-- | Helper. Or should I say melper?
+shouldResult :: ((Url -> [(Text, Text)] -> Text) -> Builder)
+             -> LT.Text
+             -> Expectation
+shouldResult h res = toLazyText (h renderUrl) `shouldBe` res
+
+-- Main
+
+spec :: Spec
+spec = do
+  let (x,y,z) = (3 :: Int, "Foo" :: Text, "Bar" :: String)
+  describe "marcus" $ do
+    it "basic" $ [marcus|Hello world|] `shouldResult` "<p>Hello world</p>"
+    it "var interpolation" $
+      [marcus|\#{x} #{y} #{z}|] `shouldResult` "<p>3 Foo Bar</p>"
+    it "heading1" $ [marcus|
+Heading
+=======
+      |] `shouldResult` "<h1>Heading</h1>"
+    it "heading2" $ [marcus|
+Heading
+-------
+      |] `shouldResult` "<h2>Heading</h2>"
+    it "heading3" $ [marcus|### Heading|] `shouldResult` "<h3>Heading</h3>"
+    it "heading with var" $ [marcus|#\#{y}|] `shouldResult` "<h1>Foo</h1>"
+    it "routes" $ [marcus|* @{Home}|] `shouldResult` "<ul><li>url</li></ul>"
+    it "Larger document" $ [marcus|
+# Just a big test document for the hell of it
+
+Here I write some lorem ipsum dolores.
+
+* Lorem
+* Ipsum
+
+1. Rutabaga
+4. *Turnip*
+1. **Squash**
+      |] `shouldResult` "<h1>Just a big test document for the hell of it</h1><p>Here I write some lorem ipsum dolores.</p><ul><li>Lorem</li><li>Ipsum</li></ul><ol><li>Rutabaga</li><li><i>Turnip</i></li><li><b>Squash</b></li></ol>"

--- a/test/Text/Shakespeare/BaseSpec.hs
+++ b/test/Text/Shakespeare/BaseSpec.hs
@@ -11,6 +11,10 @@ import Data.Text.Lazy (pack)
 
 -- run :: Text.Parsec.Prim.Parsec Text.Parsec.Pos.SourceName () c -> Text.Parsec.Pos.SourceName -> c
 
+partialShakespeareSettings = defaultShakespeareSettings unused unused unused
+  where
+    unused = error "Unused setting"
+
 spec :: Spec
 spec = do
   let preFilterN = preFilter Nothing
@@ -24,7 +28,7 @@ spec = do
   -}
 
   it "preFilter off" $ do
-    preFilterN defaultShakespeareSettings template
+    preFilterN partialShakespeareSettings template
       `shouldReturn` template
 
   it "preFilter on" $ do
@@ -41,11 +45,11 @@ spec = do
 
   it "reload" $ do
     let helper input = $(do
-            shakespeareFileReload defaultShakespeareSettings
-                { toBuilder = VarE 'pack
-                , wrap = VarE 'toLazyText
-                , unwrap = VarE 'fromLazyText
-                } "test/reload.txt") undefined
+          shakespeareFileReload
+            (defaultShakespeareSettings (VarE 'pack)
+                                        (VarE 'toLazyText)
+                                        (VarE 'fromLazyText))
+            "test/reload.txt") undefined
     helper "here1" `shouldBe` pack "here1\n"
     helper "here2" `shouldBe` pack "here2\n"
 
@@ -54,7 +58,7 @@ spec = do
     urlString = parseUrlString '@' '?'
     intString = parseIntString '^'
 
-    preConversionSettings = defaultShakespeareSettings {
+    preConversionSettings = partialShakespeareSettings {
       preConversion = Just PreConvert {
           preConvert = Id
         , preEscapeIgnoreBalanced = "'\""


### PR DESCRIPTION
This is a work in progress. The proposal is to add "marcus" as a Markdown processor, using [snoyberg/markdown](https://github.com/snoyberg/markdown). I'm basing the implementation on CoffeeScript support, since all I want is a pre-conversion and then variable interpolation.

I'm currently just adding some more tests and so forth.

Feedback appreciated.