### PR TITLE
Extend preconversion

### DIFF
--- a/Text/Julius.hs
+++ b/Text/Julius.hs
@@ -172,11 +172,8 @@ javascriptSettings = do
   wrapExp <- [|Javascript|]
   unWrapExp <- [|unJavascript|]
   asJavascriptUrl' <- [|asJavascriptUrl|]
-  return $ defaultShakespeareSettings { toBuilder = toJExp
-  , wrap = wrapExp
-  , unwrap = unWrapExp
-  , modifyFinalValue = Just asJavascriptUrl'
-  }
+  return $ (defaultShakespeareSettings toJExp wrapExp unWrapExp)
+    { modifyFinalValue = Just asJavascriptUrl' }
 
 js, julius :: QuasiQuoter
 js = QuasiQuoter { quoteExp = \s -> do
@@ -210,4 +207,7 @@ jsFileDebug = jsFileReload
 -- | Determine which identifiers are used by the given template, useful for
 -- creating systems like yesod devel.
 juliusUsedIdentifiers :: String -> [(Deref, VarType)]
-juliusUsedIdentifiers = shakespeareUsedIdentifiers defaultShakespeareSettings
+juliusUsedIdentifiers = shakespeareUsedIdentifiers partialSettings
+  where
+    unused = error "Unused setting"
+    partialSettings = defaultShakespeareSettings unused unused unused

--- a/Text/Shakespeare.hs
+++ b/Text/Shakespeare.hs
@@ -143,11 +143,18 @@ data ShakespeareSettings = ShakespeareSettings
     -- meaningful error messages.
     }
 
-defaultShakespeareSettings :: ShakespeareSettings
-defaultShakespeareSettings = ShakespeareSettings {
+defaultShakespeareSettings
+    :: Exp -- ^ An Exp that will convert variables to 'Builder'
+    -> Exp -- ^ An Exp that converts 'Builder' to the type being generated
+    -> Exp -- ^ The reversal of the previous conversion argument
+    -> ShakespeareSettings
+defaultShakespeareSettings tobuild wrapexp unwrapexp = ShakespeareSettings {
     varChar = '#'
   , urlChar = '@'
   , intChar = '^'
+  , toBuilder = tobuild
+  , wrap = wrapexp
+  , unwrap = unwrapexp
   , justVarInterpolation = False
   , preConversion = Nothing
   , modifyFinalValue = Nothing

--- a/Text/Shakespeare.hs
+++ b/Text/Shakespeare.hs
@@ -125,8 +125,7 @@ data WrapInsertion = WrapInsertion {
 
 data PreConversion = ReadProcess String [String]
                    | Id
-  
-
+                   | ConvertAction (String -> IO String)
 
 data ShakespeareSettings = ShakespeareSettings
     { varChar :: Char
@@ -274,6 +273,7 @@ preFilter mfp ShakespeareSettings {..} template =
               withVars = (addVars mWrapI vars parsed)
           in  applyVars mWrapI vars `fmap` case convert of
                   Id -> return withVars
+                  ConvertAction act -> act template
                   ReadProcess command args ->
                     readProcessError command args withVars mfp
   where

--- a/Text/Shakespeare/Text.hs
+++ b/Text/Shakespeare/Text.hs
@@ -53,11 +53,7 @@ settings = do
   toTExp <- [|toText|]
   wrapExp <- [|id|]
   unWrapExp <- [|id|]
-  return $ defaultShakespeareSettings { toBuilder = toTExp
-  , wrap = wrapExp
-  , unwrap = unWrapExp
-  }
-
+  return $ defaultShakespeareSettings toTExp wrapExp unWrapExp
 
 stext, lt, st, text, lbt, sbt :: QuasiQuoter
 stext = 
@@ -126,14 +122,12 @@ codegenSettings = do
   toTExp <- [|toText|]
   wrapExp <- [|id|]
   unWrapExp <- [|id|]
-  return $ defaultShakespeareSettings { toBuilder = toTExp
-  , wrap = wrapExp
-  , unwrap = unWrapExp
-  , varChar = '~'
-  , urlChar = '*'
-  , intChar = '&'
-  , justVarInterpolation = True -- always!
-  }
+  return $ (defaultShakespeareSettings toTExp wrapExp unWrapExp)
+    { varChar = '~'
+    , urlChar = '*'
+    , intChar = '&'
+    , justVarInterpolation = True -- always!
+    }
 
 -- | codegen is designed for generating Yesod code, including templates
 -- So it uses different interpolation characters that won't clash with templates.

--- a/test/Text/Shakespeare/BaseSpec.hs
+++ b/test/Text/Shakespeare/BaseSpec.hs
@@ -11,6 +11,10 @@ import Data.Text.Lazy (pack)
 
 -- run :: Text.Parsec.Prim.Parsec Text.Parsec.Pos.SourceName () c -> Text.Parsec.Pos.SourceName -> c
 
+partialShakespeareSettings = defaultShakespeareSettings unused unused unused
+  where
+    unused = error "Unused setting"
+
 spec :: Spec
 spec = do
   let preFilterN = preFilter Nothing
@@ -24,7 +28,7 @@ spec = do
   -}
 
   it "preFilter off" $ do
-    preFilterN defaultShakespeareSettings template
+    preFilterN partialShakespeareSettings template
       `shouldReturn` template
 
   it "preFilter on" $ do
@@ -41,11 +45,11 @@ spec = do
 
   it "reload" $ do
     let helper input = $(do
-            shakespeareFileReload defaultShakespeareSettings
-                { toBuilder = VarE 'pack
-                , wrap = VarE 'toLazyText
-                , unwrap = VarE 'fromLazyText
-                } "test/reload.txt") undefined
+          shakespeareFileReload
+            (defaultShakespeareSettings (VarE 'pack)
+                                        (VarE 'toLazyText)
+                                        (VarE 'fromLazyText))
+            "test/reload.txt") undefined
     helper "here1" `shouldBe` pack "here1\n"
     helper "here2" `shouldBe` pack "here2\n"
 
@@ -54,7 +58,7 @@ spec = do
     urlString = parseUrlString '@' '?'
     intString = parseIntString '^'
 
-    preConversionSettings = defaultShakespeareSettings {
+    preConversionSettings = partialShakespeareSettings {
       preConversion = Just PreConvert {
           preConvert = Id
         , preEscapeIgnoreBalanced = "'\""


### PR DESCRIPTION
This is the change necessary to support Markdown.

Technically I don't need a monadic function as the argument to `ConvertAction`, but it seems like a small gain to require a pure function in this situation.

The change to `defaultShakespeareSettings` will hopefully prevent other people from running into the same obscure runtime error I got when testing out my new quasiquoter.