### PR TITLE
Fixed regression caused by previous merge

### DIFF
--- a/Text/Hamlet/Parse.hs
+++ b/Text/Hamlet/Parse.hs
@@ -256,7 +256,7 @@ parseLine set = do
         x <- parseHash
         case x of
             Left "#" -> case cr of
-                          NotInQuotes -> fail "Expected hash at end of lin, got Id"
+                          NotInQuotes -> fail "Expected hash at end of line, got Id"
                           _ -> return (ContentRaw "#", False)
             Left str -> return (ContentRaw str, null str)
             Right deref -> return (ContentVar deref, False)

--- a/Text/Hamlet/Parse.hs
+++ b/Text/Hamlet/Parse.hs
@@ -256,9 +256,8 @@ parseLine set = do
         x <- parseHash
         case x of
             Left "#" -> case cr of
-                          InContent -> return (ContentRaw "#", False)
-                          NotInQuotesAttr -> return (ContentRaw "#", False)
-                          _ -> fail "Expected hash at end of line, got Id"
+                          NotInQuotes -> fail "Expected hash at end of lin, got Id"
+                          _ -> return (ContentRaw "#", False)
             Left str -> return (ContentRaw str, null str)
             Right deref -> return (ContentVar deref, False)
     contentAt = do

--- a/Text/Hamlet/Parse.hs
+++ b/Text/Hamlet/Parse.hs
@@ -257,6 +257,7 @@ parseLine set = do
         case x of
             Left "#" -> case cr of
                           InContent -> return (ContentRaw "#", False)
+                          NotInQuotesAttr -> return (ContentRaw "#", False)
                           _ -> fail "Expected hash at end of line, got Id"
             Left str -> return (ContentRaw str, null str)
             Right deref -> return (ContentVar deref, False)

--- a/test/Text/HamletSpec.hs
+++ b/test/Text/HamletSpec.hs
@@ -501,6 +501,14 @@ $case num
             ] renderer
         helperHtml "foo(5,[(\"hello\",\"world\")])bar" res
 
+    it "Hash in attribute value" $
+        helper "<a id=\"logoutbutton\" href=\"#\"></a>\n"
+        [hamlet|<a #logoutbutton href=#>|]
+
+    it "Hash in attribute value" $
+        helper "<a id=\"logoutbutton\" href=\"#\"></a>\n"
+        [hamlet|<a #logoutbutton href="#">|]
+
 data Pair = Pair String Int
 
 data Url = Home | Sub SubUrl


### PR DESCRIPTION
This should fix the regression mentioned in #200. Simply added a new test case for `NotInQuotesAttr` alongside `InContent`. Not the cleanest fix, but quick and effective.