### PR TITLE
Expose Text.Internal.Css

### DIFF
--- a/Text/Cassius.hs
+++ b/Text/Cassius.hs
@@ -40,13 +40,13 @@ module Text.Cassius
     , cassiusUsedIdentifiers
     ) where
 
-import Text.Css
+import Text.Internal.Css
 import Text.Shakespeare.Base
 import Text.Shakespeare (VarType)
 import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Language.Haskell.TH.Syntax
 import qualified Data.Text.Lazy as TL
-import Text.CssCommon
+import Text.Internal.CssCommon
 import Text.Lucius (lucius)
 import qualified Text.Lucius
 import Text.IndentToBrace (i2b)

--- a/Text/Internal/Css.hs
+++ b/Text/Internal/Css.hs
@@ -1,3 +1,6 @@
+{-# OPTIONS_HADDOCK hide #-}
+-- | This module is only being exposed to work around a GHC bug, its API is not stable
+
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -6,7 +9,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE EmptyDataDecls #-}
-module Text.Css where
+module Text.Internal.Css where
 
 import Data.List (intersperse, intercalate)
 import Data.Text.Lazy.Builder (Builder, singleton, toLazyText, fromLazyText, fromString)

--- a/Text/Internal/CssCommon.hs
+++ b/Text/Internal/CssCommon.hs
@@ -1,10 +1,13 @@
+{-# OPTIONS_HADDOCK hide #-}
+-- | This module is only being exposed to work around a GHC bug, its API is not stable
+
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE CPP #-}
-module Text.CssCommon where
+module Text.Internal.CssCommon where
 
-import Text.Css
+import Text.Internal.Css
 import Text.MkSizeType
 import qualified Data.Text as TS
 import Text.Printf (printf)

--- a/Text/Lucius.hs
+++ b/Text/Lucius.hs
@@ -51,14 +51,14 @@ module Text.Lucius
     , luciusUsedIdentifiers
     ) where
 
-import Text.CssCommon
+import Text.Internal.CssCommon
 import Text.Shakespeare.Base
 import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Language.Haskell.TH.Syntax
 import Data.Text (Text, unpack)
 import qualified Data.Text.Lazy as TL
 import Text.ParserCombinators.Parsec hiding (Line)
-import Text.Css
+import Text.Internal.Css
 import Data.Char (isSpace, toLower, toUpper)
 import Numeric (readHex)
 import Control.Applicative ((<$>))

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -66,11 +66,12 @@ library
                      Text.Shakespeare.Base
                      Text.Shakespeare
                      Text.TypeScript
+                     Text.Internal.Css
+                     Text.Internal.CssCommon
     other-modules:   Text.Hamlet.Parse
-                     Text.Css
                      Text.MkSizeType
                      Text.IndentToBrace
-                     Text.CssCommon
+
     ghc-options:     -Wall
 
     if flag(test_export)


### PR DESCRIPTION
This change allows to fix `yesod` on 8.0.1 compiler by adding:
```haskell
import Text.Internal.Css (Block(..))
```

to the failing modules
i.e. ones which die with:
```
ghc: panic! (the 'impossible' happened)
  (GHC version 8.0.1 for x86_64-unknown-linux):
        find_tycon
  Block        
  []           
               
Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug
```

fixes: https://github.com/yesodweb/shakespeare/issues/203