### PR TITLE
Handle expressions with infix operator and trailing spaces

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+### 2.0.14.1
+
+* Handle expressions with infix operator and trailing spaces [#211](https://github.com/yesodweb/shakespeare/issues/211)
+
 ### 2.0.14
 
 * Fix Cassius and Lucius reload mode [#206](https://github.com/yesodweb/shakespeare/issues/206)

--- a/Text/Shakespeare/Base.hs
+++ b/Text/Shakespeare/Base.hs
@@ -125,7 +125,8 @@ parseDeref = do
         -- special handling for $, which we don't deal with
         when (op == "$") $ fail "don't handle $"
         let op' = DerefIdent $ Ident op
-        ys <- many1 $ delim >> derefSingle
+        ys <- many1 $ try $ delim >> derefSingle
+        skipMany $ oneOf " \t"
         return $ DerefBranch (DerefBranch op' $ foldl1 DerefBranch $ x : xs) (foldl1 DerefBranch ys)
     derefSingle = derefTuple <|> derefList <|> derefOp <|> derefParens <|> numeric <|> strLit <|> ident
     deref' lhs =

--- a/Text/Shakespeare/Base.hs
+++ b/Text/Shakespeare/Base.hs
@@ -94,14 +94,13 @@ derefTuple = try $ do
   return $ DerefTuple x
 
 parseDeref :: UserParser a Deref
-parseDeref = skipMany (oneOf " \t") >> (derefList <|>
-                                        derefTuple <|> (do
-    x <- derefSingle
-    (derefInfix x) <|> (do
-        res <- deref' $ (:) x
-        skipMany $ oneOf " \t"
-        return res)))
+parseDeref = do
+    skipMany (oneOf " \t")
+    derefList <|> derefTuple <|> derefOther
   where
+    derefOther = do
+        x <- derefSingle
+        derefInfix x <|> derefPrefix x
     delim = (many1 (char ' ') >> return())
             <|> lookAhead (oneOf "(\"" >> return ())
     derefOp = try $ do
@@ -115,6 +114,10 @@ parseDeref = skipMany (oneOf " \t") >> (derefList <|>
         | isAscii c = c `elem` "!#$%&*+./<=>?@\\^|-~:"
         | otherwise = isSymbol c || isPunctuation c
 
+    derefPrefix x = do
+        res <- deref' $ (:) x
+        skipMany $ oneOf " \t"
+        return res
     derefInfix x = try $ do
         _ <- delim
         xs <- many $ try $ derefSingle >>= \x' -> delim >> return x'
@@ -124,7 +127,7 @@ parseDeref = skipMany (oneOf " \t") >> (derefList <|>
         let op' = DerefIdent $ Ident op
         ys <- many1 $ delim >> derefSingle
         return $ DerefBranch (DerefBranch op' $ foldl1 DerefBranch $ x : xs) (foldl1 DerefBranch ys)
-    derefSingle = derefTuple <|> derefList <|> derefOp <|> derefParens <|> numeric <|> strLit<|> ident
+    derefSingle = derefTuple <|> derefList <|> derefOp <|> derefParens <|> numeric <|> strLit <|> ident
     deref' lhs =
         dollar <|> derefSingle'
                <|> return (foldl1 DerefBranch $ lhs [])

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -1,5 +1,5 @@
 name:            shakespeare
-version:         2.0.14
+version:         2.0.14.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/test/Text/Shakespeare/BaseSpec.hs
+++ b/test/Text/Shakespeare/BaseSpec.hs
@@ -3,8 +3,11 @@ module Text.Shakespeare.BaseSpec (spec) where
 
 import Test.Hspec
 import Text.Shakespeare
-import Text.ParserCombinators.Parsec (parse, ParseError, (<|>))
-import Text.Shakespeare.Base (parseVarString, parseUrlString, parseIntString)
+import Text.ParserCombinators.Parsec
+       ((<|>), ParseError, parse, runParser)
+import Text.Shakespeare.Base
+       (Deref(..), Ident(..), parseDeref, parseVarString, parseUrlString,
+        parseIntString)
 import Language.Haskell.TH.Syntax (Exp (VarE))
 import Data.Text.Lazy.Builder (toLazyText, fromLazyText)
 import Data.Text.Lazy (pack)
@@ -22,6 +25,13 @@ spec = do
 
     run (varString <|> urlString <|> intString) "@{url} #{var}" `shouldBe` Right "@{url}"
   -}
+
+  it "parseDeref parse expressions with infix operator and trailing spaces" $ do
+    runParser parseDeref () "" " a + b \t " `shouldBe`
+      (Right
+         (DerefBranch
+            (DerefBranch (DerefIdent (Ident "+")) (DerefIdent (Ident "a")))
+            (DerefIdent (Ident "b"))))
 
   it "preFilter off" $ do
     preFilterN defaultShakespeareSettings template


### PR DESCRIPTION
This should fix the unnatural behaviour mentioned in #211. 