### PR TITLE
Add Semigroup instances for Javascript and Mixin

### DIFF
--- a/Text/Internal/Css.hs
+++ b/Text/Internal/Css.hs
@@ -16,6 +16,7 @@ import Data.Text.Lazy.Builder (Builder, singleton, toLazyText, fromLazyText, fro
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TLB
 import Data.Monoid (Monoid, mconcat, mappend, mempty)
+import Data.Semigroup (Semigroup(..))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Language.Haskell.TH.Syntax
@@ -28,14 +29,6 @@ import Control.Arrow ((***), second)
 import Text.IndentToBrace (i2b)
 import Data.Functor.Identity (runIdentity)
 import Text.Shakespeare (VarType (..))
-
-#if MIN_VERSION_base(4,5,0)
-import Data.Monoid ((<>))
-#else
-(<>) :: Monoid m => m -> m -> m
-(<>) = mappend
-{-# INLINE (<>) #-}
-#endif
 
 type CssUrl url = (url -> [(T.Text, T.Text)] -> T.Text) -> Css
 
@@ -74,9 +67,13 @@ data Mixin = Mixin
     { mixinAttrs :: ![Attr Resolved]
     , mixinBlocks :: ![Block Resolved]
     }
+instance Semigroup Mixin where
+    Mixin a x <> Mixin b y = Mixin (a ++ b) (x ++ y)
 instance Monoid Mixin where
     mempty = Mixin mempty mempty
-    mappend (Mixin a x) (Mixin b y) = Mixin (a ++ b) (x ++ y)
+#if !(MIN_VERSION_base(4,11,0))
+    mappend = (<>)
+#endif
 
 data TopLevel a where
     TopBlock   :: !(Block a) -> TopLevel a

--- a/Text/Julius.hs
+++ b/Text/Julius.hs
@@ -47,7 +47,8 @@ module Text.Julius
 import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Language.Haskell.TH.Syntax
 import Data.Text.Lazy.Builder (Builder, fromText, toLazyText, fromLazyText)
-import Data.Monoid
+import Data.Monoid (Monoid(..))
+import Data.Semigroup (Semigroup(..))
 import qualified Data.Text as TS
 import qualified Data.Text.Lazy as TL
 import Text.Shakespeare
@@ -76,7 +77,7 @@ renderJavascriptUrl r s = renderJavascript $ s r
 
 -- | Newtype wrapper of 'Builder'.
 newtype Javascript = Javascript { unJavascript :: Builder }
-    deriving Monoid
+    deriving (Semigroup, Monoid)
 
 -- | Return type of template-reading functions.
 type JavascriptUrl url = (url -> [(TS.Text, TS.Text)] -> TS.Text) -> Javascript

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -53,6 +53,9 @@ library
                    , unordered-containers
                    , scientific       >= 0.3.0.0
 
+    if !impl(ghc >= 8.0)
+      build-depends: semigroups       >= 0.16
+
     exposed-modules: Text.Shakespeare.I18N
                      Text.Shakespeare.Text
                      Text.Roy


### PR DESCRIPTION
This is needed to fix the build on GHC 8.4, where `Semigroup` is now a superclass of `Monoid`.