### PR TITLE
Text.Shakespeare.Text: documented how interpolation can be escaped

### DIFF
--- a/Text/Shakespeare/Text.hs
+++ b/Text/Shakespeare/Text.hs
@@ -3,6 +3,26 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
+-- | A Shakespearean module for general text processing, introducing type-safe,
+-- compile-time variable interpolation.
+--
+-- Text templates use the same parser as for other shakespearean templates
+-- which enables variable interpolation using @#{..}@.  The parser also
+-- recognize the @@{..}@ and @^{..}@ syntax.
+--
+-- If it is necessary that your template produces the output containing one of
+-- the interpolation syntax you can escape the sequence using a backslash:
+--
+-- > let bar = 23 :: Int in [lt|#{bar}|]
+--
+-- produces "23", but
+--
+-- > let bar = 23 :: Int in [lt|#\{bar}|]
+--
+-- returns "#{bar}".  The escaping backslash is removed from the output.
+--
+-- Further reading:
+-- Shakespearean templates: <https://www.yesodweb.com/book/shakespearean-templates>
 module Text.Shakespeare.Text
     ( TextUrl
     , ToText (..)


### PR DESCRIPTION
Should fix this issue.
https://github.com/yesodweb/shakespeare/issues/217

I do not understand what @{..} and ^{..} should achieve in shakespeare-text.  I could not create a useful example and just mentioned that the parser will recognize them.