### PR TITLE
deleted: drop GHC 7 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
   - $HOME/.ghc
   - $HOME/.cabal
   - $HOME/.stack
+  - $TRAVIS_BUILD_DIR/.stack-work
 
 # The different configurations we want to test. We have BUILD=cabal which uses
 # cabal-install, and BUILD=stack which uses Stack. More documentation on each
@@ -38,6 +39,12 @@ matrix:
   - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.0.2"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.2.2"
+    addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.4.3 CABALVER=2.2 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.4.3"
+    addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   # see below.
@@ -55,8 +62,16 @@ matrix:
     compiler: ": #stack 8.0.1"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-8"
+  - env: BUILD=stack ARGS="--resolver lts-9"
     compiler: ": #stack 8.0.2"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-11"
+    compiler: ": #stack 8.2.2"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-12"
+    compiler: ": #stack 8.4.3"
     addons: {apt: {packages: [libgmp-dev]}}
 
   # Nightly builds are allowed to fail
@@ -73,8 +88,16 @@ matrix:
     compiler: ": #stack 8.0.1 osx"
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-8"
+  - env: BUILD=stack ARGS="--resolver lts-9"
     compiler: ": #stack 8.0.2 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-11"
+    compiler: ": #stack 8.2.2 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-12"
+    compiler: ": #stack 8.4.3 osx"
     os: osx
 
   - env: BUILD=stack ARGS="--resolver nightly"
@@ -99,9 +122,9 @@ before_install:
 - |
   if [ `uname` = "Darwin" ]
   then
-    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+    travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
   else
-    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+    travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   fi
 
   # Use the more reliable S3 mirror of Hackage
@@ -109,10 +132,6 @@ before_install:
   echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
   echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
 
-  if [ "$CABALVER" != "1.16" ]
-  then
-    echo 'jobs: $ncpus' >> $HOME/.cabal/config
-  fi
 
 install:
 - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
@@ -121,13 +140,26 @@ install:
   set -ex
   case "$BUILD" in
     stack)
+      # Add in extra-deps for older snapshots, as necessary
+      #
+      # This is disabled by default, as relying on the solver like this can
+      # make builds unreliable. Instead, if you have this situation, it's
+      # recommended that you maintain multiple stack-lts-X.yaml files.
+
+      #stack --no-terminal --install-ghc $ARGS test --bench --dry-run || ( \
+      #  stack --no-terminal $ARGS build cabal-install && \
+      #  stack --no-terminal $ARGS solver --update-config)
+
+      # Build the dependencies
       stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
       ;;
     cabal)
       cabal --version
       travis_retry cabal update
 
-      # Get the list of packages from the stack.yaml file
+      # Get the list of packages from the stack.yaml file. Note that
+      # this will also implicitly run hpack as necessary to generate
+      # the .cabal files needed by cabal-install.
       PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
 
       cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
@@ -156,8 +188,13 @@ script:
         cd dist
         tar zxfv "$SRC_TGZ"
         cd "$PKGVER"
-        cabal configure --enable-tests
+        cabal configure --enable-tests --ghc-options -O0
         cabal build
+        if [ "$CABALVER" = "1.16" ] || [ "$CABALVER" = "1.18" ]; then
+          cabal test
+        else
+          cabal test --show-details=streaming --log=/dev/stdout
+        fi
         cd $ORIGDIR
       done
       ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,24 +35,6 @@ matrix:
   include:
   # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
   # https://github.com/hvr/multi-ghc-travis
-  #- env: BUILD=cabal GHCVER=7.0.4 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #  compiler: ": #GHC 7.0.4"
-  #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  #- env: BUILD=cabal GHCVER=7.2.2 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #  compiler: ": #GHC 7.2.2"
-  #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  #- env: BUILD=cabal GHCVER=7.4.2 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #  compiler: ": #GHC 7.4.2"
-  #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.6.3"
-    addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.8.4"
-    addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.10.3"
-    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.0.2"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
@@ -67,18 +49,6 @@ matrix:
   # variable, such as using --stack-yaml to point to a different file.
   - env: BUILD=stack ARGS=""
     compiler: ": #stack default"
-    addons: {apt: {packages: [libgmp-dev]}}
-
-  - env: BUILD=stack ARGS="--resolver lts-2"
-    compiler: ": #stack 7.8.4"
-    addons: {apt: {packages: [libgmp-dev]}}
-
-  - env: BUILD=stack ARGS="--resolver lts-3"
-    compiler: ": #stack 7.10.2"
-    addons: {apt: {packages: [libgmp-dev]}}
-
-  - env: BUILD=stack ARGS="--resolver lts-6"
-    compiler: ": #stack 7.10.3"
     addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-7"
@@ -97,19 +67,6 @@ matrix:
   # Build on macOS in addition to Linux
   - env: BUILD=stack ARGS=""
     compiler: ": #stack default osx"
-    os: osx
-
-  # Travis includes an macOS which is incompatible with GHC 7.8.4
-  #- env: BUILD=stack ARGS="--resolver lts-2"
-  #  compiler: ": #stack 7.8.4 osx"
-  #  os: osx
-
-  - env: BUILD=stack ARGS="--resolver lts-3"
-    compiler: ": #stack 7.10.2 osx"
-    os: osx
-
-  - env: BUILD=stack ARGS="--resolver lts-6"
-    compiler: ": #stack 7.10.3 osx"
     os: osx
 
   - env: BUILD=stack ARGS="--resolver lts-7"

--- a/Text/Cassius.hs
+++ b/Text/Cassius.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
 module Text.Cassius
     ( -- * Datatypes
@@ -56,9 +55,6 @@ cassius = QuasiQuoter { quoteExp = quoteExp lucius . i2b }
 
 cassiusFile :: FilePath -> Q Exp
 cassiusFile fp = do
-#ifdef GHC_7_4
-    qAddDependentFile fp
-#endif
     contents <- fmap TL.unpack $ qRunIO $ readUtf8File fp
     quoteExp cassius contents
 

--- a/Text/Hamlet/Parse.hs
+++ b/Text/Hamlet/Parse.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 module Text.Hamlet.Parse
     ( Result (..)

--- a/Text/Hamlet/RT.hs
+++ b/Text/Hamlet/RT.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -24,20 +23,11 @@ import Control.Exception (Exception)
 import Data.Typeable (Typeable)
 import Text.Hamlet.Parse
 import Data.List (intercalate)
-#if MIN_VERSION_blaze_html(0,5,0)
 import Text.Blaze.Html (Html)
 import Text.Blaze.Internal (preEscapedString, preEscapedText)
-#else
-import Text.Blaze (preEscapedString, preEscapedText, Html)
-#endif
 import Data.Text (Text)
 
-#if MIN_VERSION_exceptions(0,4,0)
 import Control.Monad.Catch (MonadThrow, throwM)
-#else
-import Control.Monad.Catch (MonadCatch, throwM)
-#define MonadThrow MonadCatch
-#endif
 
 type HamletMap url = [([String], HamletData url)]
 type UrlRenderer url = (url -> [(Text, Text)] -> Text)
@@ -131,11 +121,7 @@ renderHamletRT :: MonadThrow m
                -> m Html
 renderHamletRT = renderHamletRT' False
 
-#if MIN_VERSION_exceptions(0,4,0)
 renderHamletRT' :: MonadThrow m
-#else
-renderHamletRT' :: MonadCatch m
-#endif
                 => Bool -- ^ should embeded template (via ^{..}) be plain Html or actual templates?
                 -> HamletRT
                 -> HamletMap url
@@ -192,12 +178,7 @@ renderHamletRT' tempAsHtml (HamletRT docs) scope0 renderUrl =
                 renderHamletRT' tempAsHtml (HamletRT docs') scope renderUrl
             HDBool False -> go scope (SDCond cs els)
             _ -> fa $ showName b ++ ": expected HDBool"
-#if MIN_VERSION_exceptions(0,4,0)
-    lookup' :: MonadThrow m
-#else
-    lookup' :: MonadCatch m
-#endif
-            => [String] -> [String] -> HamletMap url -> m (HamletData url)
+    lookup' :: MonadThrow m => [String] -> [String] -> HamletMap url -> m (HamletData url)
     lookup' orig k m =
         case lookup k m of
             Nothing | k == ["True"] -> return $ HDBool True
@@ -210,11 +191,7 @@ fa = throwM . HamletRenderException
 showName :: [String] -> String
 showName = intercalate "." . reverse
 
-#if MIN_VERSION_exceptions(0,4,0)
 flattenDeref' :: MonadThrow f => Doc -> Deref -> f [String]
-#else
-flattenDeref' :: MonadCatch f => Doc -> Deref -> f [String]
-#endif
 flattenDeref' orig deref =
     case flattenDeref deref of
         Nothing -> throwM $ HamletUnsupportedDocException orig

--- a/Text/Internal/Css.hs
+++ b/Text/Internal/Css.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PatternGuards #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 module Text.Internal.Css where
@@ -71,9 +70,6 @@ instance Semigroup Mixin where
     Mixin a x <> Mixin b y = Mixin (a ++ b) (x ++ y)
 instance Monoid Mixin where
     mempty = Mixin mempty mempty
-#if !(MIN_VERSION_base(4,11,0))
-    mappend = (<>)
-#endif
 
 data TopLevel a where
     TopBlock   :: !(Block a) -> TopLevel a
@@ -108,9 +104,6 @@ data CDData url = CDPlain Builder
 
 pack :: String -> Text
 pack = T.pack
-#if !MIN_VERSION_text(0, 11, 2)
-{-# NOINLINE pack #-}
-#endif
 
 fromText :: Text -> Builder
 fromText = TLB.fromText

--- a/Text/Internal/CssCommon.hs
+++ b/Text/Internal/CssCommon.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE CPP #-}
 module Text.Internal.CssCommon where
 
 import Text.Internal.Css

--- a/Text/Lucius.hs
+++ b/Text/Lucius.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
 module Text.Lucius
@@ -223,9 +222,6 @@ parseComment = do
 
 luciusFile :: FilePath -> Q Exp
 luciusFile fp = do
-#ifdef GHC_7_4
-    qAddDependentFile fp
-#endif
     contents <- fmap TL.unpack $ qRunIO $ readUtf8File fp
     luciusFromString contents
 

--- a/Text/MkSizeType.hs
+++ b/Text/MkSizeType.hs
@@ -3,7 +3,7 @@
 -- | Internal functions to generate CSS size wrapper types.
 module Text.MkSizeType (mkSizeType) where
 
-#if MIN_VERSION_template_haskell(2,11,0)
+#if !MIN_VERSION_template_haskell(2,12,0)
 import Language.Haskell.TH (conT)
 #endif
 import Language.Haskell.TH.Syntax
@@ -25,10 +25,8 @@ dataDec name =
 #if MIN_VERSION_template_haskell(2,12,0)
   return $
     DataD [] name [] Nothing [constructor] [DerivClause Nothing (map ConT derives)]
-#elif MIN_VERSION_template_haskell(2,11,0)
-  DataD [] name [] Nothing [constructor] <$> mapM conT derives
 #else
-  return $ DataD [] name [] [constructor] derives
+  DataD [] name [] Nothing [constructor] <$> mapM conT derives
 #endif
   where constructor = NormalC name [(notStrict, ConT $ mkName "Rational")]
         derives = map mkName ["Eq", "Ord"]
@@ -88,17 +86,8 @@ unariFunDec2 name fun' = FunD fun [Clause [pat] body []]
         fun = mkName fun'
         x = mkName "x"
 
-#if MIN_VERSION_template_haskell(2,11,0)
 notStrict :: Bang
 notStrict = Bang NoSourceUnpackedness NoSourceStrictness
-#else
-notStrict :: Strict
-notStrict = NotStrict
-#endif
 
 instanceD :: Cxt -> Type -> [Dec] -> Dec
-#if MIN_VERSION_template_haskell(2,11,0)
 instanceD = InstanceD Nothing
-#else
-instanceD = InstanceD
-#endif

--- a/Text/Shakespeare.hs
+++ b/Text/Shakespeare.hs
@@ -41,11 +41,10 @@ import Text.Parsec.Prim (modifyState, Parsec)
 import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Language.Haskell.TH (appE)
 import Language.Haskell.TH.Syntax
-#if !MIN_VERSION_template_haskell(2,8,0)
-import Language.Haskell.TH.Syntax.Internals
-#endif
 import Data.Text.Lazy.Builder (Builder, fromText)
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid
+#endif
 import System.IO.Unsafe (unsafePerformIO)
 import qualified Data.Text as TS
 import qualified Data.Text.Lazy as TL
@@ -62,12 +61,6 @@ import Data.Data (Data)
 -- for pre conversion
 import System.Process (readProcessWithExitCode)
 import System.Exit (ExitCode(..))
-
-#if !MIN_VERSION_base(4,5,0)
-(<>) :: Monoid m => m -> m -> m
-(<>) = mappend
-{-# INLINE (<>) #-}
-#endif
 
 -- | A parser with a user state of [String]
 type Parser = Parsec String [String]
@@ -344,9 +337,6 @@ preFilter mfp ShakespeareSettings {..} template =
 
 pack' :: String -> TS.Text
 pack' = TS.pack
-#if !MIN_VERSION_text(0, 11, 2)
-{-# NOINLINE pack' #-}
-#endif
 
 contentsToShakespeare :: ShakespeareSettings -> [Content] -> Q Exp
 contentsToShakespeare rs a = do
@@ -394,11 +384,7 @@ shakespeareFromString r str = do
     contentsToShakespeare r $ contentFromString r s
 
 shakespeareFile :: ShakespeareSettings -> FilePath -> Q Exp
-shakespeareFile r fp =
-#ifdef GHC_7_4
-    qAddDependentFile fp >>
-#endif
-        readFileQ fp >>= shakespeareFromString r
+shakespeareFile r fp = readFileQ fp >>= shakespeareFromString r
 
 data VarType = VTPlain | VTUrl | VTUrlParam | VTMixin
     deriving (Show, Eq, Ord, Enum, Bounded, Typeable, Data, Generic)

--- a/Text/Shakespeare/Text.hs
+++ b/Text/Shakespeare/Text.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
 module Text.Shakespeare.Text
     ( TextUrl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,37 @@
+build: off
+
+before_test:
+# http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
+- set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+
+- curl -sS -ostack.zip -L --insecure https://get.haskellstack.org/stable/windows-x86_64.zip
+- 7z x stack.zip stack.exe
+
+clone_folder: "c:\\stack"
+environment:
+  global:
+    STACK_ROOT: "c:\\sr"
+
+    # Override the temp directory to avoid sed escaping issues
+    # See https://github.com/haskell/cabal/issues/5386
+    TMP: "c:\\tmp"
+
+  matrix:
+  - ARGS: ""
+  #- ARGS: "--resolver lts-2"
+  #- ARGS: "--resolver lts-3"
+  #- ARGS: "--resolver lts-6"
+  - ARGS: "--resolver lts-7"
+  - ARGS: "--resolver lts-9"
+  - ARGS: "--resolver lts-11"
+  - ARGS: "--resolver lts-12"
+  #- ARGS: "--resolver nightly"
+
+test_script:
+
+# Install toolchain, but do it silently due to lots of output
+- stack %ARGS% setup > nul
+
+# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
+# descriptor
+- echo "" | stack %ARGS% --no-terminal test

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -34,7 +34,7 @@ extra-source-files:
   ChangeLog.md
 
 library
-    build-depends:   base             >= 4       && < 5
+    build-depends:   base             >= 4.9     && < 5
                    , time             >= 1
                    , containers
                    , template-haskell >= 2.7
@@ -52,9 +52,6 @@ library
                    , vector
                    , unordered-containers
                    , scientific       >= 0.3.0.0
-
-    if !impl(ghc >= 8.0)
-      build-depends: semigroups       >= 0.16
 
     exposed-modules: Text.Shakespeare.I18N
                      Text.Shakespeare.Text
@@ -81,9 +78,6 @@ library
       cpp-options: -DTEST_EXPORT
 
     extensions: TemplateHaskell
-
-    if impl(ghc >= 7.4)
-       cpp-options: -DGHC_7_4
 
     if os(windows)
       CPP-Options: "-DWINDOWS"
@@ -127,7 +121,7 @@ test-suite test
     type: exitcode-stdio-1.0
 
     ghc-options:   -Wall
-    build-depends: base             >= 4       && < 5
+    build-depends: base             >= 4.9     && < 5
                  , shakespeare
                  , time             >= 1
                  , containers

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-6.14
+resolver: lts-12.8


### PR DESCRIPTION
Yesod drop support GHC 7.
[yesod/.travis.yml at cdba6c1678d8002eac94ba175e00183a7e87c09d ·
yesodweb/yesod](https://github.com/yesodweb/yesod/blob/cdba6c1678d8002eac94ba175e00183a7e87c09d/.travis.yml)

GHC 7 is slow, and GHC 7 support add CPP switch.
To drop GHC 7 get correct travis test and simple code.

I delete unneed CPP pragma.

And I run stylish-haskell all source code.
Because I want to detect unneed import.