### PR TITLE
deleted: default-extensions

### DIFF
--- a/Text/MkSizeType.hs
+++ b/Text/MkSizeType.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- | Internal functions to generate CSS size wrapper types.
 module Text.MkSizeType (mkSizeType) where

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -77,8 +77,6 @@ library
     if flag(test_export)
       cpp-options: -DTEST_EXPORT
 
-    extensions: TemplateHaskell
-
     if os(windows)
       CPP-Options: "-DWINDOWS"
 
@@ -139,8 +137,6 @@ test-suite test
                  , blaze-markup
                  , blaze-html
                  , exceptions
-
-    extensions: TemplateHaskell
 
 
 source-repository head


### PR DESCRIPTION
cabal extensions break to coding tool coding tools such as stylish-haskell and hlint.
Yesod Scaffolding use language pragma.
[Updated Yesod Scaffolding](https://www.yesodweb.com/blog/2017/06/updated-yesod-scaffolding)