### PR TITLE
Add stextFile to Text.Shakespeare.Text

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for shakespeare
 
+### 2.0.22
+
+* Add `stextFile` to `Text.Shakespeare.Text`, which can be used to produce `Text` directly in the same way `shamletFile` can be used to produce `Html` directly. [#240](https://github.com/yesodweb/shakespeare/pull/240)
+
 ### 2.0.21
 
 * Support for GHC 8.8

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -1,5 +1,5 @@
 name:            shakespeare
-version:         2.0.21
+version:         2.0.22
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/test/Text/Shakespeare/TextSpec.hs
+++ b/test/Text/Shakespeare/TextSpec.hs
@@ -68,6 +68,9 @@ spec = do
       writeFile "test/texts/external2.text" "var #{var} = 1;"
       -}
 
+    it "stextFile" $ do
+      let var = "somevar"
+      TL.toStrict $(stextFile "test/texts/external2.text") @=? pack "var somevar = 2;"
 
     it "text module names" $
       let foo = "foo"


### PR DESCRIPTION
This adds `stextFile` to `Text.Shakespeare.Text`, which is to `textFile` as `shamletFile` is to `hamletFile`.