### PR TITLE
Derive Lift instances wherever possible

### DIFF
--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -52,6 +52,7 @@ library
                    , vector
                    , unordered-containers
                    , scientific       >= 0.3.0.0
+                   , th-lift
 
     exposed-modules: Text.Shakespeare.I18N
                      Text.Shakespeare.Text


### PR DESCRIPTION
Many of `shakespeare`'s `Lift` instances are equivalent to what would be generated by `DeriveLift`, so this patch switches them over to use `deriving`. For those instances that do not easily admit derived instances, I made sure that `liftTyped` was defined to avoid warnings when compiling with `template-haskell-2.16.*` (GHC 8.10). One example of such an instance is the `Lift ShakespeareSettings` instance, which relies on lifting `Exp`s and `Name`s from `template-haskell`. Since there is a canonical `Lift Name` orphan instance defined in the widely used, lightweight `th-lift` package, I decided to just add a dependency on that. This allows making the implementation of the `Lift ShakespeareSettings` instance slightly cleaner.