### PR TITLE
Updates for GHC 9 and template-haskell 2.17.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for shakespeare
 
+### 2.0.25
+
+* Support for GHC 9.0 [#254](https://github.com/yesodweb/shakespeare/pull/254)
+
 ### 2.0.24.1
 
 * Derive Lift instances wherever possible [#252](https://github.com/yesodweb/shakespeare/pull/252)

--- a/Text/Hamlet.hs
+++ b/Text/Hamlet.hs
@@ -110,7 +110,11 @@ docsToExp env hr scope docs = do
     case exps of
         [] -> [|return ()|]
         [x] -> return x
-        _ -> return $ DoE $ map NoBindS exps
+        _ -> return $ DoE
+#if MIN_VERSION_template_haskell(2,17,0)
+                Nothing
+#endif
+                $ map NoBindS exps
 
 unIdent :: Ident -> String
 unIdent (Ident s) = s

--- a/Text/Hamlet/Parse.hs
+++ b/Text/Hamlet/Parse.hs
@@ -625,7 +625,9 @@ data NewlineStyle = NoNewlines -- ^ never add newlines
 
 instance Lift (String -> CloseStyle) where
     lift _ = [|\s -> htmlCloseStyle s|]
-#if MIN_VERSION_template_haskell(2,16,0)
+#if MIN_VERSION_template_haskell(2,17,0)
+    liftTyped = unsafeCodeCoerce . lift
+#elif MIN_VERSION_template_haskell(2,16,0)
     liftTyped = unsafeTExpCoerce . lift
 #endif
 

--- a/Text/Lucius.hs
+++ b/Text/Lucius.hs
@@ -334,7 +334,7 @@ luciusRTInternal tl =
             -> Block Unresolved
             -> Either String [Block Resolved]
     goBlock scope =
-        either Left (Right . ($[])) . blockRuntime scope' (error "luciusRT has no URLs")
+        either Left (Right . ($ [])) . blockRuntime scope' (error "luciusRT has no URLs")
       where
         scope' = map goScope scope
 

--- a/Text/Shakespeare.hs
+++ b/Text/Shakespeare.hs
@@ -152,7 +152,9 @@ instance Lift ShakespeareSettings where
         liftExp _ = error "liftExp only supports VarE and ConE"
         liftMExp Nothing = [|Nothing|]
         liftMExp (Just e) = [|Just|] `appE` liftExp e
-#if MIN_VERSION_template_haskell(2,16,0)
+#if MIN_VERSION_template_haskell(2,17,0)
+    liftTyped = unsafeCodeCoerce . lift
+#elif MIN_VERSION_template_haskell(2,16,0)
     liftTyped = unsafeTExpCoerce . lift
 #endif
 

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -1,5 +1,5 @@
 name:            shakespeare
-version:         2.0.24.1
+version:         2.0.25
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
These were changes I needed to build under the recently released `ghc-9.0.1-alpha`, mostly due to Template Haskell 2.17 updates.

1.  Because of the `-XQualifiedDo` extension, `DoE` now takes an extra argument of a `Maybe ModName`.

2.  A newtype `Code` was added in https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3358, so that we use `unsafeCodeCoerce` instead of `unsafeTExpCoerce`.

3.  A function had to be explicitly generalized from `Q x` to the new `Quote m => m x`.

4.  Because of https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst, `($[])` is interpreted as a splice rather than a slice.  We just have to insert a space after the `$`.