### PR TITLE
Add support for sub-blocks in mixins

### DIFF
--- a/test/Text/CssSpec.hs
+++ b/test/Text/CssSpec.hs
@@ -427,14 +427,11 @@ foo { foo:X#{bar}Y; }
     it "lucius mixins" $ do
         let bins = [luciusMixin|
                    bin:bin2;
-                   /* FIXME not currently implementing sublocks in mixins
                    foo2 {
-                       x: y
+                       x: y;
                    }
-                   */
                    |] :: Mixin
-        -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
-        celper "foo{bar:baz;bin:bin2}" [lucius|
+        celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
             foo {
                 bar: baz;
                 ^{bins}
@@ -444,9 +441,11 @@ foo { foo:X#{bar}Y; }
         let bins = [cassiusMixin|
                    bin:bin2
                    bin3:bin4
+
+                   foo2
+                       x:y
                    |] :: Mixin
-        -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
-        celper "foo{bar:baz;bin:bin2;bin3:bin4}" [lucius|
+        celper "foo{bar:baz;bin:bin2;bin3:bin4}foo foo2{x:y}" [lucius|
             foo {
                 bar: baz;
                 ^{bins}
@@ -469,17 +468,43 @@ foo { foo:X#{bar}Y; }
                     }
                 |]
 
+    it "nested mixin blocks" $ do
+        let bar = [luciusMixin|
+                  bar {
+                     bin:baz;
+                  }
+                  |]
+            foo = [luciusMixin|
+                  foo {
+                    ^{bar}
+                  }
+                  |] :: Mixin
+        celper "selector foo bar{bin:baz}" [lucius|
+            selector {
+                ^{foo}
+            }
+        |]
+
+    it "mixins with pseudoselectors" $ do
+        let bar = [luciusMixin|
+                  &:hover {
+                     bin:baz;
+                  }
+                  |] :: Mixin
+        celper "foo:hover{bin:baz}" [lucius|
+            foo {
+                ^{bar}
+            }
+        |]
+
     it "runtime mixin" $ do
         let bins = [luciusMixin|
                    bin:bin2;
-                   /* FIXME not currently implementing sublocks in mixins
                    foo2 {
-                       x: y
+                       x: y;
                    }
-                   */
                    |] :: Mixin
-        -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
-        Right (T.pack "foo{bar:baz;bin:bin2}") @=? luciusRTMixin
+        Right (T.pack "foo{bar:baz;bin:bin2}foo foo2{x:y}") @=? luciusRTMixin
             (T.pack "foo { bar: baz; ^{bins} }")
             True
             [(TS.pack "bins", RTVMixin bins)]

--- a/test/Text/CssSpec.hs
+++ b/test/Text/CssSpec.hs
@@ -601,7 +601,7 @@ encodeUrlChar y =
 
 
 
-celper :: String -> CssUrl Url -> Assertion
+celper :: HasCallStack => String -> CssUrl Url -> Assertion
 celper res h = do
     let x = renderCssUrl render h
     T.pack res @=? x


### PR DESCRIPTION
Fixes a TODO!

This has been a recent pain point for us, because we have a button mixin that basically wants to do this
```
&__button {
  &:hover {
    ...
  }
  ...
}
```
But we can't, because of the lack of blocks in mixins. Instead, we're forced to have multiple mixins per call-site, which is nasty.