### PR TITLE
Make embedded files be resolved by project root

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ### 2.0.27
 
 * Change how embedded templates are located by the compiler. Relative files are now resolved using the Cabal project root, to fix builds of multi-project codebases. [#266](https://github.com/yesodweb/shakespeare/pull/266)
+* Change how messages are located by the compiler. The message directory is now resolved using the Cabal project root, to fix builds of multi-project codebases. [#266](https://github.com/yesodweb/shakespeare/pull/266)
 
 ### 2.0.26
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for shakespeare
 
+### 2.0.27
+
+* Change how embedded templates are located by the compiler. Relative files are now resolved using the Cabal project root, to fix builds of multi-project codebases. [#266](https://github.com/yesodweb/shakespeare/pull/266)
+
 ### 2.0.26
 
 * Support `@supports` [#263](https://github.com/yesodweb/shakespeare/pull/263)

--- a/Text/Shakespeare/Base.hs
+++ b/Text/Shakespeare/Base.hs
@@ -30,6 +30,7 @@ module Text.Shakespeare.Base
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH (appE)
 import Data.Char (isUpper, isSymbol, isPunctuation, isAscii)
+import Data.FileEmbed (makeRelativeToProject)
 import Text.ParserCombinators.Parsec
 import Text.Parsec.Prim (Parsec)
 import Data.List (intercalate)
@@ -283,11 +284,16 @@ readUtf8File fp = do
 --
 -- @since 2.0.19
 readFileQ :: FilePath -> Q String
-readFileQ fp = qRunIO (readUtf8FileString fp)
+readFileQ rawFp = do
+  fp <- makeRelativeToProject rawFp
+  qRunIO (readUtf8FileString fp)
 
 -- | Embed file's content, converting newlines
 -- and track file via ghc dependencies, recompiling on changes
 --
 -- @since 2.0.19
 readFileRecompileQ :: FilePath -> Q String
-readFileRecompileQ fp = addDependentFile fp >> readFileQ fp
+readFileRecompileQ rawFp = do
+  fp <- makeRelativeToProject rawFp
+  addDependentFile fp
+  qRunIO (readUtf8FileString fp)

--- a/Text/Shakespeare/I18N.hs
+++ b/Text/Shakespeare/I18N.hs
@@ -66,6 +66,7 @@ import Control.Applicative ((<$>))
 import Control.Monad (filterM, forM)
 import Data.Text (Text, pack, unpack)
 import System.Directory
+import Data.FileEmbed (makeRelativeToProject)
 import Data.Maybe (catMaybes)
 import Data.List (isSuffixOf, sortBy, foldl')
 import qualified Data.Map as Map
@@ -152,7 +153,8 @@ mkMessageCommon :: Bool      -- ^ generate a new datatype from the constructors 
                 -> FilePath  -- ^ path to translation folder
                 -> Lang      -- ^ default lang
                 -> Q [Dec]
-mkMessageCommon genType prefix postfix master dt folder lang = do
+mkMessageCommon genType prefix postfix master dt rawFolder lang = do
+    folder <- makeRelativeToProject rawFolder
     files <- qRunIO $ getDirectoryContents folder
     let files' = filter (`notElem` [".", ".."]) files
     (filess, contents) <- qRunIO $ fmap (unzip . catMaybes) $ mapM (loadLang folder) files'

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -1,5 +1,5 @@
 name:            shakespeare
-version:         2.0.26
+version:         2.0.27
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -49,6 +49,7 @@ library
                    , blaze-markup
                    , blaze-html
                    , exceptions
+                   , file-embed       >= 0.0.1   && < 0.1
                    , transformers
                    , vector
                    , unordered-containers


### PR DESCRIPTION
Because file embedding runs IO in the Template Haskell `Q` monad, relative file paths are resolved by the compiler's working directory. Ordinarily, this is the root of the project being built - but if the compiler is e.g. building a dependency, it can also be different.

This change makes it so that template files are always embedded relative to the project that contains the code embedding them, rather than the working directory of the compiler - this means that dependencies in a multi-project codebase can embed files correctly.