### PR TITLE
Keep attributes and mixins in ordering

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,8 @@
 
 ### 2.0.30
 
-* Add new cassius and lucius parsers to maintain order between attributes and mixin blocks.
+* Add `Text.Cassius.Ordered` and `Text.Lucius.Ordered` modules with parsers to maintain order between attributes and mixin blocks.
+
 ### 2.0.29
 
 * Support the upcoming `template-haskell` release with GHC 9.4 [#267](https://github.com/yesodweb/shakespeare/pull/267)
@@ -49,9 +50,11 @@
 * Support for GHC 8.8
 
 ### 2.0.20
+
 * Restore allowing GHC to detect changes to i18n message files in GHC >= 8.4.
 
 ### 2.0.19
+
 * Change of the default behaviour of `*File` functions, they now will add their templates' source file to ghc-dependencies, thus recompiling on templates' changes.
 
 ### 2.0.18
@@ -153,48 +156,40 @@ shakespeare-i18n supports message directories.
 ### Hamlet 0.5.0 (August 29, 2010)
 
 * Use can use parantheses when referencing variables. This allows you to have
-functions applied to multiple arguments.
-
+  functions applied to multiple arguments.
 * Added the hamlet' and xhamlet' quasiquoters for generating plain Html
-values.
-
+  values.
 * Added runtime Hamlet support.
-
 * Added "file debug" support. This is a mode that is a drop-in replacement for
-external files compiled via template haskell. However, this mode also has a
-runtime component, in that is reads your templates at runtime, thus avoiding
-the need to a recompile for each template change. This takes a runtime hit
-obviously, so it's recommended that you switch back to the compile-time
-templates for production systems.
-
+  external files compiled via template haskell. However, this mode also has a
+  runtime component, in that is reads your templates at runtime, thus avoiding
+  the need to a recompile for each template change. This takes a runtime hit
+  obviously, so it's recommended that you switch back to the compile-time
+  templates for production systems.
 * Added the Cassius and Julius template languages for CSS and Javascript,
-respectively. The former is white-space sensitive, whereas the latter is just
-a passthrough for raw Javascript code. The big feature in both of them is that
-they support variable interpolation just like Hamlet does.
+  respectively. The former is white-space sensitive, whereas the latter is just
+  a passthrough for raw Javascript code. The big feature in both of them is that
+  they support variable interpolation just like Hamlet does.
 
 ### New in Hamlet 0.4.0
 
 * Internal template parsing is now done via Parsec. This opened the doors for
-the other changes mentioned below, but also hopefully gives more meaningful
-error messages. There's absolutely no runtime performance hit for this change,
-since all parsing is done at compile time, and if there *is* any compile-time
-hit, it's too negligible to be noticed.
-
+  the other changes mentioned below, but also hopefully gives more meaningful
+  error messages. There's absolutely no runtime performance hit for this change,
+  since all parsing is done at compile time, and if there *is* any compile-time
+  hit, it's too negligible to be noticed.
 * Attribute values can now be quoted. This allows you to embed spaces, periods
-and pounds in an attribute value. For example:
-[$hamlet|%input!type=submit!value="Add new value"|].
-
+  and pounds in an attribute value. For example:
+  [$hamlet|%input!type=submit!value="Add new value"|].
 * Space-delimited references in addition to period-delimited ones. This only
-applies to references in content, not in statements. For example, you could
-write [\$hamlet|\$foo bar baz\$|].
-
+  applies to references in content, not in statements. For example, you could
+  write [\$hamlet|\$foo bar baz\$|].
 * Dollar-sign interpolation is now polymorphic, based on the ToHtml typeclass.
-You can now do away with \$string.var\$ and simply type \$var\$. Currently, the
-ToHtml typeclass is not exposed, and it only provides instances for String and
-Html, though this is open for discussion.
-
+  You can now do away with \$string.var\$ and simply type \$var\$. Currently, the
+  ToHtml typeclass is not exposed, and it only provides instances for String and
+  Html, though this is open for discussion.
 * Added hamletFile and xhamletFile which loads a Hamlet template from an
-external file. The file is parsed at compile time, just like a quasi-quoted
-template, and must be UTF-8 encoded. Additionally, be warned that the compiler
-won't automatically know to recompile a module if the template file gets
-changed.
+  external file. The file is parsed at compile time, just like a quasi-quoted
+  template, and must be UTF-8 encoded. Additionally, be warned that the compiler
+  won't automatically know to recompile a module if the template file gets
+  changed.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # ChangeLog for shakespeare
 
-### 2.0.28
+### 2.0.30
 
 * Add new cassius and lucius parsers to maintain order between attributes and mixin blocks.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for shakespeare
 
+### 2.0.28
+
+* Add new cassius and lucius parsers to maintain order between attributes and mixin blocks.
+
 ### 2.0.27
 
 * Change how embedded templates are located by the compiler. Relative files are now resolved using the Cabal project root, to fix builds of multi-project codebases. [#266](https://github.com/yesodweb/shakespeare/pull/266)

--- a/Text/Cassius.hs
+++ b/Text/Cassius.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
@@ -48,7 +47,7 @@ import Text.Internal.Cassius (i2bMixin)
 import Text.Internal.Css
 import Text.Internal.CssCommon
 import Text.Internal.Lucius (parseTopLevels)
-import Text.Lucius qualified as Lucius
+import qualified Text.Lucius as Lucius
 import Text.Shakespeare (VarType)
 import Text.Shakespeare.Base
 

--- a/Text/Cassius.hs
+++ b/Text/Cassius.hs
@@ -14,11 +14,16 @@ module Text.Cassius
     , renderCssUrl
       -- * Parsing
     , cassius
+    , cassiusOrd
     , cassiusFile
+    , cassiusFileOrd
     , cassiusFileDebug
+    , cassiusFileDebugOrd
     , cassiusFileReload
+    , cassiusFileReloadOrd
       -- ** Mixims
     , cassiusMixin
+    , cassiusMixinOrd
     , Mixin
       -- * ToCss instances
       -- ** Color
@@ -46,26 +51,63 @@ import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Language.Haskell.TH.Syntax
 import qualified Data.Text.Lazy as TL
 import Text.Internal.CssCommon
-import Text.Lucius (lucius)
+import Text.Lucius (lucius, luciusOrd)
 import qualified Text.Lucius
 import Text.IndentToBrace (i2b)
 
 cassius :: QuasiQuoter
 cassius = QuasiQuoter { quoteExp = quoteExp lucius . i2b }
+{-# DEPRECATED cassius "Use 'cassiusOrd' instead" #-}
+
+-- | Like 'cassius' but preserves the order of attributes and mixins
+-- @since 2.0.28
+cassiusOrd :: QuasiQuoter
+cassiusOrd = QuasiQuoter { quoteExp = quoteExp luciusOrd . i2b }
 
 cassiusFile :: FilePath -> Q Exp
-cassiusFile fp = do
-    contents <- readFileRecompileQ fp
-    quoteExp cassius contents
+cassiusFile = cassiusFileWithOrder Unordered
+{-# DEPRECATED cassiusFile "Use 'cassiusFileOrd' instead" #-}
 
-cassiusFileDebug, cassiusFileReload :: FilePath -> Q Exp
-cassiusFileDebug = cssFileDebug True [|Text.Lucius.parseTopLevels|] Text.Lucius.parseTopLevels
+-- | Like 'cassiusFile' but preserves the order of attributes and mixins
+-- @since 2.0.28
+cassiusFileOrd :: FilePath -> Q Exp
+cassiusFileOrd = cassiusFileWithOrder Ordered
+
+cassiusFileWithOrder :: Order -> FilePath -> Q Exp
+cassiusFileWithOrder order fp = do
+  let qq = case order of
+            Unordered -> cassius
+            Ordered   -> cassiusOrd
+  contents <- readFileRecompileQ fp
+  quoteExp qq contents
+
+cassiusFileDebug :: FilePath -> Q Exp
+cassiusFileDebug = cassiusFileDebugWithOrder Unordered
+{-# DEPRECATED cassiusFileDebug "Use 'cassiusFileDebugOrd' instead" #-}
+
+cassiusFileReload :: FilePath -> Q Exp
 cassiusFileReload = cassiusFileDebug
+{-# DEPRECATED cassiusFileReload "Use 'cassiusFileReloadOrd' instead" #-}
+
+-- | Like 'cassiusFileDebug' but preserves the order of attributes and mixins
+-- @since 2.0.28
+cassiusFileDebugOrd :: FilePath -> Q Exp
+cassiusFileDebugOrd = cassiusFileDebugWithOrder Ordered
+
+-- | Like 'cassiusFileReload' but preserves the order of attributes and mixins
+-- @since 2.0.28
+cassiusFileReloadOrd :: FilePath -> Q Exp
+cassiusFileReloadOrd = cassiusFileDebugOrd
+
+cassiusFileDebugWithOrder :: Order -> FilePath -> Q Exp
+cassiusFileDebugWithOrder order =
+  cssFileDebug True [|Text.Lucius.parseTopLevels order|] (Text.Lucius.parseTopLevels order)
 
 -- | Determine which identifiers are used by the given template, useful for
 -- creating systems like yesod devel.
-cassiusUsedIdentifiers :: String -> [(Deref, VarType)]
-cassiusUsedIdentifiers = cssUsedIdentifiers True Text.Lucius.parseTopLevels
+cassiusUsedIdentifiers :: Order -> String -> [(Deref, VarType)]
+cassiusUsedIdentifiers order =
+  cssUsedIdentifiers True (Text.Lucius.parseTopLevels order)
 
 -- | Create a mixin with Cassius syntax.
 --
@@ -73,6 +115,14 @@ cassiusUsedIdentifiers = cssUsedIdentifiers True Text.Lucius.parseTopLevels
 cassiusMixin :: QuasiQuoter
 cassiusMixin = QuasiQuoter
     { quoteExp = quoteExp Text.Lucius.luciusMixin . i2bMixin
+    }
+{-# DEPRECATED cassiusMixin "Use 'cassiusMixinOrd' instead" #-}
+
+-- | Like 'cassiusMixin' but preserves the order of attributes and mixins
+-- @since 2.0.28
+cassiusMixinOrd :: QuasiQuoter
+cassiusMixinOrd = QuasiQuoter
+    { quoteExp = quoteExp Text.Lucius.luciusMixinOrd . i2bMixin
     }
 
 i2bMixin :: String -> String

--- a/Text/Cassius.hs
+++ b/Text/Cassius.hs
@@ -60,7 +60,7 @@ cassius = QuasiQuoter { quoteExp = quoteExp lucius . i2b }
 {-# DEPRECATED cassius "Use 'cassiusOrd' instead" #-}
 
 -- | Like 'cassius' but preserves the order of attributes and mixins
--- @since 2.0.28
+-- @since 2.0.30
 cassiusOrd :: QuasiQuoter
 cassiusOrd = QuasiQuoter { quoteExp = quoteExp luciusOrd . i2b }
 
@@ -69,7 +69,7 @@ cassiusFile = cassiusFileWithOrder Unordered
 {-# DEPRECATED cassiusFile "Use 'cassiusFileOrd' instead" #-}
 
 -- | Like 'cassiusFile' but preserves the order of attributes and mixins
--- @since 2.0.28
+-- @since 2.0.30
 cassiusFileOrd :: FilePath -> Q Exp
 cassiusFileOrd = cassiusFileWithOrder Ordered
 
@@ -90,12 +90,12 @@ cassiusFileReload = cassiusFileDebug
 {-# DEPRECATED cassiusFileReload "Use 'cassiusFileReloadOrd' instead" #-}
 
 -- | Like 'cassiusFileDebug' but preserves the order of attributes and mixins
--- @since 2.0.28
+-- @since 2.0.30
 cassiusFileDebugOrd :: FilePath -> Q Exp
 cassiusFileDebugOrd = cassiusFileDebugWithOrder Ordered
 
 -- | Like 'cassiusFileReload' but preserves the order of attributes and mixins
--- @since 2.0.28
+-- @since 2.0.30
 cassiusFileReloadOrd :: FilePath -> Q Exp
 cassiusFileReloadOrd = cassiusFileDebugOrd
 
@@ -119,7 +119,7 @@ cassiusMixin = QuasiQuoter
 {-# DEPRECATED cassiusMixin "Use 'cassiusMixinOrd' instead" #-}
 
 -- | Like 'cassiusMixin' but preserves the order of attributes and mixins
--- @since 2.0.28
+-- @since 2.0.30
 cassiusMixinOrd :: QuasiQuoter
 cassiusMixinOrd = QuasiQuoter
     { quoteExp = quoteExp Text.Lucius.luciusMixinOrd . i2bMixin

--- a/Text/Cassius/Ordered.hs
+++ b/Text/Cassius/Ordered.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
 
-module Text.Cassius
+module Text.Cassius.Ordered
     ( -- * Datatypes
       Css
     , CssUrl
@@ -48,33 +48,38 @@ import Text.Internal.Cassius (i2bMixin)
 import Text.Internal.Css
 import Text.Internal.CssCommon
 import Text.Internal.Lucius (parseTopLevels)
-import Text.Lucius qualified as Lucius
+import Text.Lucius.Ordered qualified as Lucius.Ordered
 import Text.Shakespeare (VarType)
 import Text.Shakespeare.Base
 
+-- | @since 2.0.30
 cassius :: QuasiQuoter
-cassius = QuasiQuoter { quoteExp = quoteExp Lucius.lucius . i2b }
+cassius = QuasiQuoter { quoteExp = quoteExp Lucius.Ordered.lucius . i2b }
 
+-- | @since 2.0.30
 cassiusFile :: FilePath -> Q Exp
 cassiusFile fp = do
     contents <- readFileRecompileQ fp
     quoteExp cassius contents
 
+-- | @since 2.0.30
 cassiusFileDebug :: FilePath -> Q Exp
-cassiusFileDebug = cssFileDebug True [|parseTopLevels Unordered|] (parseTopLevels Unordered)
+cassiusFileDebug = cssFileDebug True [|parseTopLevels Ordered|] (parseTopLevels Ordered)
 
+-- | @since 2.0.30
 cassiusFileReload :: FilePath -> Q Exp
 cassiusFileReload = cassiusFileDebug
 
 -- | Determine which identifiers are used by the given template, useful for
 -- creating systems like yesod devel.
+-- | @since 2.0.30
 cassiusUsedIdentifiers :: String -> [(Deref, VarType)]
-cassiusUsedIdentifiers = cssUsedIdentifiers True (parseTopLevels Unordered)
+cassiusUsedIdentifiers = cssUsedIdentifiers True (parseTopLevels Ordered)
 
 -- | Create a mixin with Cassius syntax.
 --
--- Since 2.0.3
+-- | @since 2.0.30
 cassiusMixin :: QuasiQuoter
 cassiusMixin = QuasiQuoter
-    { quoteExp = quoteExp Lucius.luciusMixin . i2bMixin
+    { quoteExp = quoteExp Lucius.Ordered.luciusMixin . i2bMixin
     }

--- a/Text/Cassius/Ordered.hs
+++ b/Text/Cassius/Ordered.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
@@ -62,7 +61,7 @@ import Text.Internal.Cassius (i2bMixin)
 import Text.Internal.Css
 import Text.Internal.CssCommon
 import Text.Internal.Lucius (parseTopLevels)
-import Text.Lucius.Ordered qualified as Lucius.Ordered
+import qualified Text.Lucius.Ordered as Lucius.Ordered
 import Text.Shakespeare (VarType)
 import Text.Shakespeare.Base
 

--- a/Text/Cassius/Ordered.hs
+++ b/Text/Cassius/Ordered.hs
@@ -5,6 +5,20 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
 
+-- | This module is the twin brother of module Text.Cassius.
+-- The difference is that these parsers preserv the given order of attributes and mixin blocks.
+--
+-- > let bams = [cassiusMixin|
+-- >               bam1:bam2
+-- >               ^{bins}
+-- >               bam3:bam4
+-- >            |] :: Mixin
+-- >     bins = [cassiusMixin|
+-- >               bin1:bin2
+-- >            |] :: Mixin
+-- >  in renderCss ([Text.Ordered.lucius|foo{bar1:bar2;^{bams};bar3:bar4;}|] undefined)
+-- > "foo{bar1:bar2;bam1:bam2;bin1:bin2;bam3:bam4;bar3:bar4}"
+
 module Text.Cassius.Ordered
     ( -- * Datatypes
       Css

--- a/Text/Internal/Cassius.hs
+++ b/Text/Internal/Cassius.hs
@@ -1,9 +1,8 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Text.Internal.Cassius (i2bMixin) where
 
-import Data.Text.Lazy qualified as TL
+import qualified Data.Text.Lazy as TL
 import Text.IndentToBrace (i2b)
 
 i2bMixin :: String -> String

--- a/Text/Internal/Cassius.hs
+++ b/Text/Internal/Cassius.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Text.Internal.Cassius (i2bMixin) where
+
+import Data.Text.Lazy qualified as TL
+import Text.IndentToBrace (i2b)
+
+i2bMixin :: String -> String
+i2bMixin s' =
+    TL.unpack
+        $ stripEnd "}"
+        $ stripFront "mixin {"
+        $ TL.strip
+        $ TL.pack
+        $ i2b
+        $ unlines
+        $ "mixin" : (map ("    " ++) $ lines s')
+  where
+    stripFront x y =
+        case TL.stripPrefix x y of
+            Nothing -> y
+            Just z -> z
+    stripEnd x y =
+        case TL.stripSuffix x y of
+            Nothing -> y
+            Just z -> z

--- a/Text/Internal/Lucius.hs
+++ b/Text/Internal/Lucius.hs
@@ -1,0 +1,357 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# OPTIONS_GHC -fno-warn-missing-fields #-}
+
+module Text.Internal.Lucius where
+
+import Text.Shakespeare.Base
+import Language.Haskell.TH.Quote (QuasiQuoter (..))
+import Language.Haskell.TH.Syntax
+import Data.Text (Text, unpack)
+import qualified Data.Text.Lazy as TL
+import Text.ParserCombinators.Parsec hiding (Line)
+import Text.Internal.Css
+import Data.Char (isSpace, toLower, toUpper)
+import Numeric (readHex)
+import Control.Monad (when, unless)
+import Data.List (isSuffixOf)
+import Control.Arrow (second)
+import Text.Shakespeare (VarType)
+
+luciusWithOrder :: Order -> QuasiQuoter
+luciusWithOrder order = QuasiQuoter { quoteExp = luciusFromString order}
+
+luciusFromString :: Order -> String -> Q Exp
+luciusFromString order s =
+    topLevelsToCassius
+  $ either (error . show) id $ parse (parseTopLevels order) s s
+
+whiteSpace :: Parser ()
+whiteSpace = many whiteSpace1 >> return ()
+
+whiteSpace1 :: Parser ()
+whiteSpace1 =
+    ((oneOf " \t\n\r" >> return ()) <|> (parseComment >> return ()))
+
+parseBlock :: Order -> Parser (Block 'Unresolved)
+parseBlock order = do
+    sel <- parseSelector
+    _ <- char '{'
+    whiteSpace
+    pairsBlocks <- parsePairsBlocks order id
+    let (attrs, blocks) = partitionPBs order pairsBlocks
+    whiteSpace
+    return $ BlockUnresolved sel attrs (map detectAmp blocks)
+
+-- | Looks for an & at the beginning of a selector and, if present, indicates
+-- that we should not have a leading space. Otherwise, we should have the
+-- leading space.
+detectAmp :: Block 'Unresolved -> (Bool, Block 'Unresolved)
+detectAmp (BlockUnresolved (sel) b c) =
+    (hls, BlockUnresolved sel' b c)
+  where
+    (hls, sel') =
+        case sel of
+            (ContentRaw "&":rest):others -> (False, rest : others)
+            (ContentRaw ('&':s):rest):others -> (False, (ContentRaw s : rest) : others)
+            _ -> (True, sel)
+
+partitionPBs ::
+     Order
+  -> [PairBlock]
+  -> ([Either (Attr 'Unresolved) Deref], [Block 'Unresolved])
+partitionPBs order = go id id id
+  where
+    -- We append the unordered legacy mixins 'c' to the end of the ordered list 'a'
+    go a b c [] = (a $ c [], b [])
+    go a b c (PBAttr x:xs) = go (a . ((Left x):)) b c xs
+    go a b c (PBBlock x:xs) = go a (b . (x:)) c xs
+    go a b c (PBMixin x:xs) = case order of
+      -- If we are interested in order, then we collect attributes and mixins in one list 'a'.
+      Ordered   -> go (a . ((Right x):)) b c xs
+      -- Otherwise (legacy style) we collect mixins in a separate list 'c'.
+      Unordered -> go a b (c . (Right x:)) xs
+
+parseSelector :: Parser [Contents]
+parseSelector =
+    go id
+  where
+    go front = do
+        c <- parseContents "{,"
+        let front' = front . (:) (trim c)
+        (char ',' >> go front') <|> return (front' [])
+
+trim :: Contents -> Contents
+trim =
+    reverse . trim' False . reverse . trim' True
+  where
+    trim' _ [] = []
+    trim' b (ContentRaw s:rest) =
+        let s' = trimS b s
+         in if null s' then trim' b rest else ContentRaw s' : rest
+    trim' _ x = x
+    trimS True = dropWhile isSpace
+    trimS False = reverse . dropWhile isSpace . reverse
+
+data PairBlock = PBAttr (Attr 'Unresolved)
+               | PBBlock (Block 'Unresolved)
+               | PBMixin Deref
+parsePairsBlocks :: Order -> ([PairBlock] -> [PairBlock]) -> Parser [PairBlock]
+parsePairsBlocks order front = (char '}' >> return (front [])) <|> (do
+    isBlock <- lookAhead checkIfBlock
+    x <- grabMixin <|> (if isBlock then grabBlock else grabPair)
+    parsePairsBlocks order $ front . (:) x)
+  where
+    grabBlock = do
+        b <- parseBlock order
+        whiteSpace
+        return $ PBBlock b
+    grabPair = PBAttr <$> parsePair
+    grabMixin = try $ do
+        whiteSpace
+        Right x <- parseCaret
+        whiteSpace
+        (char ';' >> return ()) <|> return ()
+        whiteSpace
+        return $ PBMixin x
+    checkIfBlock = do
+        skipMany $ noneOf "#@{};"
+        (parseHash >> checkIfBlock)
+            <|> (parseAt >> checkIfBlock)
+            <|> (char '{' >> return True)
+            <|> (oneOf ";}" >> return False)
+            <|> (anyChar >> checkIfBlock)
+            <|> fail "checkIfBlock"
+
+parsePair :: Parser (Attr 'Unresolved)
+parsePair = do
+    key <- parseContents ":"
+    _ <- char ':'
+    whiteSpace
+    val <- parseContents ";}"
+    (char ';' >> return ()) <|> return ()
+    whiteSpace
+    return $ AttrUnresolved key val
+
+parseContents :: String -> Parser Contents
+parseContents = many1 . parseContent
+
+parseContent :: String -> Parser Content
+parseContent restricted =
+    parseHash' <|> parseAt' <|> parseComment <|> parseBack <|> parseChar
+  where
+    parseHash' = either ContentRaw ContentVar `fmap` parseHash
+    parseAt' =
+        either ContentRaw go `fmap` parseAt
+      where
+        go (d, False) = ContentUrl d
+        go (d, True) = ContentUrlParam d
+    parseBack = try $ do
+        _ <- char '\\'
+        hex <- atMost 6 $ satisfy isHex
+        (int, _):_ <- return $ readHex $ dropWhile (== '0') hex
+        when (length hex < 6) $
+            ((string "\r\n" >> return ()) <|> (satisfy isSpace >> return ()))
+        return $ ContentRaw [toEnum int]
+    parseChar = (ContentRaw . return) `fmap` noneOf restricted
+
+isHex :: Char -> Bool
+isHex c =
+    ('0' <= c && c <= '9') ||
+    ('A' <= c && c <= 'F') ||
+    ('a' <= c && c <= 'f')
+
+atMost :: Int -> Parser a -> Parser [a]
+atMost 0 _ = return []
+atMost i p = (do
+    c <- p
+    s <- atMost (i - 1) p
+    return $ c : s) <|> return []
+
+parseComment :: Parser Content
+parseComment = do
+    _ <- try $ string "/*"
+    _ <- manyTill anyChar $ try $ string "*/"
+    return $ ContentRaw ""
+
+luciusFileWithOrd :: Order -> FilePath -> Q Exp
+luciusFileWithOrd order fp = do
+    contents <- readFileRecompileQ fp
+    luciusFromString order contents
+
+luciusFileDebugWithOrder :: Order -> FilePath -> Q Exp
+luciusFileDebugWithOrder order =
+  cssFileDebug False [|parseTopLevels order|] (parseTopLevels order)
+
+parseTopLevels :: Order -> Parser [TopLevel 'Unresolved]
+parseTopLevels order =
+    go id
+  where
+    go front = do
+        let string' s = string s >> return ()
+            ignore = many (whiteSpace1 <|> string' "<!--" <|> string' "-->")
+                        >> return ()
+        ignore
+        tl <- ((charset <|> media <|> impor <|> supports <|> topAtBlock <|> var <|> fmap TopBlock (parseBlock order)) >>= \x -> go (front . (:) x))
+            <|> (return $ map compressTopLevel $ front [])
+        ignore
+        return tl
+    charset = do
+        try $ stringCI "@charset "
+        cs <- parseContents ";"
+        _ <- char ';'
+        return $ TopAtDecl "charset" cs
+    media = do
+        try $ stringCI "@media "
+        selector <- parseContents "{"
+        _ <- char '{'
+        b <- parseBlocks id
+        return $ TopAtBlock "media" selector b
+    impor = do
+        try $ stringCI "@import ";
+        val <- parseContents ";"
+        _ <- char ';'
+        return $ TopAtDecl "import" val
+    supports = do
+        try $ stringCI "@supports "
+        selector <- parseContents "{"
+        _ <- char '{'
+        b <- parseBlocks id
+        return $ TopAtBlock "supports" selector b
+    var = try $ do
+        _ <- char '@'
+        isPage <- (try $ string "page " >> return True) <|>
+                  (try $ string "font-face " >> return True) <|>
+                    return False
+        when isPage $ fail "page is not a variable"
+        k <- many1 $ noneOf ":"
+        _ <- char ':'
+        v <- many1 $ noneOf ";"
+        _ <- char ';'
+        let trimS = reverse . dropWhile isSpace . reverse . dropWhile isSpace
+        return $ TopVar (trimS k) (trimS v)
+    topAtBlock = do
+        (name, selector) <- try $ do
+            _ <- char '@'
+            name <- many1 $ noneOf " \t"
+            _ <- many1 $ oneOf " \t"
+            unless ("keyframes" `isSuffixOf` name) $ fail "only accepting keyframes"
+            selector <- parseContents "{"
+            _ <- char '{'
+            return (name, selector)
+        b <- parseBlocks id
+        return $ TopAtBlock name selector b
+    parseBlocks front = do
+        whiteSpace
+        (char '}' >> return (map compressBlock $ front []))
+            <|> ((parseBlock order) >>= \x -> parseBlocks (front . (:) x))
+
+stringCI :: String -> Parser ()
+stringCI [] = return ()
+stringCI (c:cs) = (char (toLower c) <|> char (toUpper c)) >> stringCI cs
+
+luciusRTWithOrder'::
+     Order -- ^ Should we keep attributes and mixins order or not
+  -> TL.Text
+  -> Either String ([(Text, Text)] -> Either String [TopLevel 'Resolved])
+luciusRTWithOrder' order =
+    either Left (Right . go) . luciusRTInternal order
+  where
+    go :: ([(Text, RTValue)] -> Either String [TopLevel 'Resolved])
+       -> ([(Text, Text)] -> Either String [TopLevel 'Resolved])
+    go f = f . map (second RTVRaw)
+
+luciusRTInternal ::
+     Order
+  -> TL.Text
+  -> Either String ([(Text, RTValue)]
+  -> Either String [TopLevel 'Resolved])
+luciusRTInternal order tl =
+    case parse (parseTopLevels order) (TL.unpack tl) (TL.unpack tl) of
+        Left s -> Left $ show s
+        Right tops -> Right $ \scope -> go scope tops
+  where
+    go :: [(Text, RTValue)]
+       -> [TopLevel 'Unresolved]
+       -> Either String [TopLevel 'Resolved]
+    go _ [] = Right []
+    go scope (TopAtDecl dec cs':rest) = do
+        let scope' = map goScope scope
+            render = error "luciusRT has no URLs"
+        cs <- mapM (contentToBuilderRT scope' render) cs'
+        rest' <- go scope rest
+        Right $ TopAtDecl dec (mconcat cs) : rest'
+    go scope (TopBlock b:rest) = do
+        b' <- goBlock scope b
+        rest' <- go scope rest
+        Right $ map TopBlock b' ++ rest'
+    go scope (TopAtBlock name m' bs:rest) = do
+        let scope' = map goScope scope
+            render = error "luciusRT has no URLs"
+        m <- mapM (contentToBuilderRT scope' render) m'
+        bs' <- mapM (goBlock scope) bs
+        rest' <- go scope rest
+        Right $ TopAtBlock name (mconcat m) (concat bs') : rest'
+    go scope (TopVar k v:rest) = go ((pack k, RTVRaw $ pack v):scope) rest
+
+    goBlock :: [(Text, RTValue)]
+            -> Block 'Unresolved
+            -> Either String [Block 'Resolved]
+    goBlock scope =
+        either Left (Right . ($ [])) . blockRuntime scope' (error "luciusRT has no URLs")
+      where
+        scope' = map goScope scope
+
+    goScope (k, rt) =
+        (DerefIdent (Ident $ unpack k), cd)
+      where
+        cd =
+            case rt of
+                RTVRaw t -> CDPlain $ fromText t
+                RTVMixin m -> CDMixin m
+
+luciusRTWithOrder :: Order -> TL.Text -> [(Text, Text)] -> Either String TL.Text
+luciusRTWithOrder order tl scope =
+  either Left (Right . renderCss . CssWhitespace) $ either Left ($ scope) (luciusRTWithOrder' order tl)
+
+luciusRTMixinWithOrder ::
+     Order
+  -> TL.Text -- ^ template
+  -> Bool -- ^ minify?
+  -> [(Text, RTValue)] -- ^ scope
+  -> Either String TL.Text
+luciusRTMixinWithOrder order tl minify scope =
+    either Left (Right . renderCss . cw) $ either Left ($ scope) (luciusRTInternal order tl)
+  where
+    cw | minify = CssNoWhitespace
+       | otherwise = CssWhitespace
+
+data RTValue = RTVRaw Text
+             | RTVMixin Mixin
+
+luciusRTMinifiedWithOrder :: Order -> TL.Text -> [(Text, Text)] -> Either String TL.Text
+luciusRTMinifiedWithOrder order tl scope =
+  either Left (Right . renderCss . CssNoWhitespace) $ either Left ($ scope) (luciusRTWithOrder' order tl)
+
+-- | Determine which identifiers are used by the given template, useful for
+-- creating systems like yesod devel.
+luciusUsedIdentifiers :: Order -> String -> [(Deref, VarType)]
+luciusUsedIdentifiers order = cssUsedIdentifiers False (parseTopLevels order)
+
+luciusMixinWithOrder :: Order -> QuasiQuoter
+luciusMixinWithOrder order = QuasiQuoter { quoteExp = luciusMixinFromString order}
+
+luciusMixinFromString :: Order -> String -> Q Exp
+luciusMixinFromString order s' = do
+    r <- newName "_render"
+    case fmap compressBlock $ parse (parseBlock order) s s of
+        Left e -> error $ show e
+        Right block -> blockToMixin r [] block
+  where
+    s = concat ["mixin{", s', "}"]

--- a/Text/Lucius.hs
+++ b/Text/Lucius.hs
@@ -86,7 +86,7 @@ lucius = luciusWithOrder Unordered
 {-# DEPRECATED lucius "Use 'luciusOrd' instead" #-}
 
 -- | Like 'lucius' but preserves the order of attributes and mixins
--- @since 2.0.28
+-- @since 2.0.30
 luciusOrd :: QuasiQuoter
 luciusOrd = luciusWithOrder Ordered
 
@@ -261,7 +261,7 @@ luciusFile = luciusFileWithOrd Unordered
 {-# DEPRECATED luciusFile "Use 'luciusFileOrd' instead" #-}
 
 -- | Like 'luciusFile' but preserves the order of attributes and mixins
--- @since 2.0.28
+-- @since 2.0.30
 luciusFileOrd :: FilePath -> Q Exp
 luciusFileOrd = luciusFileWithOrd Ordered
 
@@ -279,12 +279,12 @@ luciusFileReload = luciusFileDebug
 {-# DEPRECATED luciusFileReload "Use 'luciusFileReloadOrd' instead" #-}
 
 -- | Like 'luciusFileDebug' but preserves the order of attributes and mixins
--- @since 2.0.28
+-- @since 2.0.30
 luciusFileDebugOrd :: FilePath -> Q Exp
 luciusFileDebugOrd = luciusFileDebugWithOrder Ordered
 
 -- | Like 'luciusFileReload' but preserves the order of attributes and mixins
--- @since 2.0.28
+-- @since 2.0.30
 luciusFileReloadOrd :: FilePath -> Q Exp
 luciusFileReloadOrd = luciusFileDebugOrd
 
@@ -365,7 +365,7 @@ luciusRT' = luciusRTWithOrder' Unordered
 {-# DEPRECATED luciusRT' "Use luciusRT' instead" #-}
 
 -- | Like @luciusRT'@ but preserves the order of attributes and mixins
--- @since 2.0.28
+-- @since 2.0.30
 luciusRTOrd' :: TL.Text
           -> Either String ([(Text, Text)] -> Either String [TopLevel 'Resolved])
 luciusRTOrd' = luciusRTWithOrder' Ordered
@@ -435,7 +435,7 @@ luciusRT = luciusRTWithOrder Unordered
 {-# DEPRECATED luciusRT "Use 'luciusRTOrd' instead" #-}
 
 -- | Like 'luciusRT' but preserves the order of attributes and mixins
--- @since 2.0.28
+-- @since 2.0.30
 luciusRTOrd :: TL.Text -> [(Text, Text)] -> Either String TL.Text
 luciusRTOrd = luciusRTWithOrder Ordered
 
@@ -454,7 +454,7 @@ luciusRTMixin = luciusRTMixinWithOrder Unordered
 {-# DEPRECATED luciusRTMixin "Use 'luciusRTMixinOrd' instead" #-}
 
 -- | Like 'luciusRTMixin' but preserves the order of attributes and mixins.
--- @since 2.0.28
+-- @since 2.0.30
 luciusRTMixinOrd :: TL.Text -- ^ template
               -> Bool -- ^ minify?
               -> [(Text, RTValue)] -- ^ scope
@@ -484,7 +484,7 @@ luciusRTMinified = luciusRTMinifiedWithOrder Unordered
 {-# DEPRECATED luciusRTMinified "Use 'luciusRTMinifiedOrd' instead" #-}
 
 -- | Like 'luciusRTMinified' but preserves the order of attributes and mixins.
--- @since 2.0.28
+-- @since 2.0.30
 luciusRTMinifiedOrd :: TL.Text -> [(Text, Text)] -> Either String TL.Text
 luciusRTMinifiedOrd = luciusRTMinifiedWithOrder Ordered
 
@@ -502,7 +502,7 @@ luciusMixin = luciusMixinWithOrder Unordered
 {-# DEPRECATED luciusMixin "Use 'luciusMixinOrd' instead" #-}
 
 -- | Like 'luciusMixin' but preserves the order of attributes and mixins.
--- @since 2.0.28
+-- @since 2.0.30
 luciusMixinOrd :: QuasiQuoter
 luciusMixinOrd = luciusMixinWithOrder Ordered
 

--- a/Text/Lucius/Ordered.hs
+++ b/Text/Lucius/Ordered.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
-module Text.Lucius
+module Text.Lucius.Ordered
     ( -- * Parsing
       lucius
     , luciusFile
@@ -63,42 +63,43 @@ import Text.Internal.Css
 --
 -- >>> renderCss ([lucius|foo{bar:baz}|] undefined)
 -- "foo{bar:baz}"
+-- @since 2.0.30
 lucius :: QuasiQuoter
-lucius = luciusWithOrder Unordered
+lucius = luciusWithOrder Ordered
 
+-- | @since 2.0.30
 luciusFile :: FilePath -> Q Exp
-luciusFile = luciusFileWithOrd Unordered
+luciusFile = luciusFileWithOrd Ordered
 
+-- | @since 2.0.30
 luciusFileDebug :: FilePath -> Q Exp
-luciusFileDebug = luciusFileDebugWithOrder Unordered
+luciusFileDebug = luciusFileDebugWithOrder Ordered
 
+-- | @since 2.0.30
 luciusFileReload :: FilePath -> Q Exp
 luciusFileReload = luciusFileDebug
 
-
+-- | @since 2.0.30
 luciusRT' :: TL.Text
-          -> Either String ([(Text, Text)] -> Either String [TopLevel 'Resolved])
-luciusRT' = luciusRTWithOrder' Unordered
+          -> Either String ([(Text, Text)]
+          -> Either String [TopLevel 'Resolved])
+luciusRT' = luciusRTWithOrder' Ordered
 
+-- | @since 2.0.30
 luciusRT :: TL.Text -> [(Text, Text)] -> Either String TL.Text
-luciusRT = luciusRTWithOrder Unordered
+luciusRT = luciusRTWithOrder Ordered
 
-
--- | Runtime Lucius with mixin support.
---
--- Since 1.0.6
+-- | @since 2.0.30
 luciusRTMixin :: TL.Text -- ^ template
               -> Bool -- ^ minify?
               -> [(Text, RTValue)] -- ^ scope
               -> Either String TL.Text
-luciusRTMixin = luciusRTMixinWithOrder Unordered
+luciusRTMixin = luciusRTMixinWithOrder Ordered
 
--- | Same as 'luciusRT', but output has no added whitespace.
---
--- Since 1.0.3
+-- | @since 2.0.30
 luciusRTMinified :: TL.Text -> [(Text, Text)] -> Either String TL.Text
-luciusRTMinified = luciusRTMinifiedWithOrder Unordered
+luciusRTMinified = luciusRTMinifiedWithOrder Ordered
 
+-- | @since 2.0.30
 luciusMixin :: QuasiQuoter
-luciusMixin = luciusMixinWithOrder Unordered
-
+luciusMixin = luciusMixinWithOrder Ordered

--- a/Text/Lucius/Ordered.hs
+++ b/Text/Lucius/Ordered.hs
@@ -7,6 +7,21 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
+
+-- | This module is the twin brother of module Text.Lucius.
+-- The difference is that these parsers preserv the given order of attributes and mixin blocks.
+--
+-- > let bams = [Text.Ordered.cassiusMixin|
+-- >               bam1:bam2
+-- >               ^{bins}
+-- >               bam3:bam4
+-- >            |] :: Mixin
+-- >     bins = [Text.Ordered.cassiusMixin|
+-- >               bin1:bin2
+-- >            |] :: Mixin
+-- >  in renderCss ([lucius|foo{bar1:bar2;^{bams};bar3:bar4;}|] undefined)
+-- > "foo{bar1:bar2;bam1:bam2;bin1:bin2;bam3:bam4;bar3:bar4}"
+
 module Text.Lucius.Ordered
     ( -- * Parsing
       lucius
@@ -59,10 +74,11 @@ import Data.Text (Text)
 import qualified Data.Text.Lazy as TL
 import Text.Internal.Css
 
+
 -- |
---
 -- >>> renderCss ([lucius|foo{bar:baz}|] undefined)
 -- "foo{bar:baz}"
+--
 -- @since 2.0.30
 lucius :: QuasiQuoter
 lucius = luciusWithOrder Ordered

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -65,12 +65,16 @@ library
                      Text.Hamlet.RT
                      Text.Hamlet.Runtime
                      Text.Lucius
+                     Text.Lucius.Ordered
                      Text.Cassius
+                     Text.Cassius.Ordered
                      Text.Shakespeare.Base
                      Text.Shakespeare
                      Text.TypeScript
+                     Text.Internal.Cassius
                      Text.Internal.Css
                      Text.Internal.CssCommon
+                     Text.Internal.Lucius
     other-modules:   Text.Hamlet.Parse
                      Text.MkSizeType
                      Text.IndentToBrace

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -1,5 +1,5 @@
 name:            shakespeare
-version:         2.0.28
+version:         2.0.30
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -1,5 +1,5 @@
 name:            shakespeare
-version:         2.0.27
+version:         2.0.28
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/test/Text/CssSpec.hs
+++ b/test/Text/CssSpec.hs
@@ -8,14 +8,15 @@ import Test.Hspec
 
 import Prelude hiding (reverse)
 import Text.Cassius
+import qualified Text.Cassius.Ordered as Ordered
 import Text.Lucius
+import qualified Text.Lucius.Ordered as Ordered
 import Data.List (intercalate)
 import qualified Data.Text.Lazy as T
 import qualified Data.Text as TS
 import qualified Data.List
 import qualified Data.List as L
 import Data.Text (Text, pack, unpack)
-import Data.Monoid (mappend)
 
 spec :: Spec
 spec = do
@@ -514,6 +515,114 @@ foo { foo:X#{bar}Y; }
             }
         |]
 
+    it "mixins insane structure" $ do
+        let bar = [luciusMixin|
+                    bar1:bar2;
+                    ^{bim}
+                    &:hover {
+                        ^{bim}
+                        jam1:jam2;
+                        ^{bam}
+                    }
+                    
+                    ram {
+                        ram1:ram2;
+                        ^{bim}
+                        ^{bam}
+                    }
+                    ^{bam}
+                    bar3:bar4;
+                  |] :: Mixin
+            bim = [luciusMixin|
+                    bim1:bim2;
+                    bim-block1 {
+                      bim3:bim4;
+                      bim5:bim6;
+                    }
+                    bim-block2 {
+                      bim7:bim8;
+                      bim9:bim10;
+                    }
+                  |]
+            bam = [luciusMixin|
+                    bam1:bam2;
+                    bam-block1 {
+                      bam3:bam4;
+                      bam5:bam6;
+                    }
+                    bam-block2 {
+                      bam7:bam8;
+                      bam9:bam10;
+                    }
+                  |]
+                  
+        celper
+            -- 1. attributes
+            -- 2. mixins attributes 
+            -- 3. blocks
+            -- 4. mixins blocks
+            "foo{foo1:foo2;foo3:foo4;bar1:bar2;bar3:bar4;bim1:bim2;bam1:bam2}\
+
+            \foo foo-block1{bar1:bar2;bar3:bar4;bim1:bim2;bam1:bam2}\
+            \foo foo-block1:hover{jam1:jam2;bim1:bim2;bam1:bam2}\
+            \foo foo-block1:hover bim-block1{bim3:bim4;bim5:bim6}\
+            \foo foo-block1:hover bim-block2{bim7:bim8;bim9:bim10}\
+            \foo foo-block1:hover bam-block1{bam3:bam4;bam5:bam6}\
+            \foo foo-block1:hover bam-block2{bam7:bam8;bam9:bam10}\
+            \foo foo-block1 ram{ram1:ram2;bim1:bim2;bam1:bam2}\
+            \foo foo-block1 ram bim-block1{bim3:bim4;bim5:bim6}\
+            \foo foo-block1 ram bim-block2{bim7:bim8;bim9:bim10}\
+            \foo foo-block1 ram bam-block1{bam3:bam4;bam5:bam6}\
+            \foo foo-block1 ram bam-block2{bam7:bam8;bam9:bam10}\
+            \foo foo-block1 bim-block1{bim3:bim4;bim5:bim6}\
+            \foo foo-block1 bim-block2{bim7:bim8;bim9:bim10}\
+            \foo foo-block1 bam-block1{bam3:bam4;bam5:bam6}\
+            \foo foo-block1 bam-block2{bam7:bam8;bam9:bam10}\
+
+            \foo foo-block2{bar1:bar2;bar3:bar4;bim1:bim2;bam1:bam2}\
+            \foo foo-block2:hover{jam1:jam2;bim1:bim2;bam1:bam2}\
+            \foo foo-block2:hover bim-block1{bim3:bim4;bim5:bim6}\
+            \foo foo-block2:hover bim-block2{bim7:bim8;bim9:bim10}\
+            \foo foo-block2:hover bam-block1{bam3:bam4;bam5:bam6}\
+            \foo foo-block2:hover bam-block2{bam7:bam8;bam9:bam10}\
+            \foo foo-block2 ram{ram1:ram2;bim1:bim2;bam1:bam2}\
+            \foo foo-block2 ram bim-block1{bim3:bim4;bim5:bim6}\
+            \foo foo-block2 ram bim-block2{bim7:bim8;bim9:bim10}\
+            \foo foo-block2 ram bam-block1{bam3:bam4;bam5:bam6}\
+            \foo foo-block2 ram bam-block2{bam7:bam8;bam9:bam10}\
+            \foo foo-block2 bim-block1{bim3:bim4;bim5:bim6}\
+            \foo foo-block2 bim-block2{bim7:bim8;bim9:bim10}\
+            \foo foo-block2 bam-block1{bam3:bam4;bam5:bam6}\
+            \foo foo-block2 bam-block2{bam7:bam8;bam9:bam10}\
+
+            \foo:hover{jam1:jam2;bim1:bim2;bam1:bam2}\
+            \foo:hover bim-block1{bim3:bim4;bim5:bim6}\
+            \foo:hover bim-block2{bim7:bim8;bim9:bim10}\
+            \foo:hover bam-block1{bam3:bam4;bam5:bam6}\
+            \foo:hover bam-block2{bam7:bam8;bam9:bam10}\
+            \foo ram{ram1:ram2;bim1:bim2;bam1:bam2}\
+            \foo ram bim-block1{bim3:bim4;bim5:bim6}\
+            \foo ram bim-block2{bim7:bim8;bim9:bim10}\
+            \foo ram bam-block1{bam3:bam4;bam5:bam6}\
+            \foo ram bam-block2{bam7:bam8;bam9:bam10}\
+            \foo bim-block1{bim3:bim4;bim5:bim6}\
+            \foo bim-block2{bim7:bim8;bim9:bim10}\
+            \foo bam-block1{bam3:bam4;bam5:bam6}\
+            \foo bam-block2{bam7:bam8;bam9:bam10}"
+            [lucius|
+                foo {
+                    foo1:foo2;
+                    ^{bar}
+                    foo-block1 {
+                        ^{bar}
+                    }
+                    foo-block2 {
+                        ^{bar}
+                    }
+                    foo3:foo4;
+                }
+                |]
+
     it "runtime mixin" $ do
         let bins = [luciusMixin|
                    bin:bin2;
@@ -580,16 +689,16 @@ foo { foo:X#{bar}Y; }
             |]
 
   describe "Ordered parsers" $ do
-    it "cassiusOrd" caseCassiusOrd
-    it "cassiusFileOrd" caseCassiusFileOrd
-    it "cassiusOrd single comment" caseCassiusSingleCommentOrd
-    it "cassiusOrd leading comment" caseCassiusLeadingCommentOrd
+    it "Ordered.cassius" caseCassiusOrd
+    it "Ordered.cassiusFile" caseCassiusFileOrd
+    it "Ordered.cassius single comment" caseCassiusSingleCommentOrd
+    it "Ordered.cassius leading comment" caseCassiusLeadingCommentOrd
 
-    it "cassiusFileDebugOrd" $ do
+    it "cassiusFileDebug" $ do
       let var = "var"
       let selector = "foo"
       let urlp = (Home, [(pack "p", pack "q")])
-      flip celper $(cassiusFileDebugOrd "test/cassiuses/external1.cassius") $ concat
+      flip celper $(cassiusFileDebug "test/cassiuses/external1.cassius") $ concat
           [ "foo {\n    background: #000;\n    bar: baz;\n    color: #F00;\n}\n"
           , "bin {\n"
           , "    background-image: url(url);\n"
@@ -607,22 +716,22 @@ foo { foo:X#{bar}Y; }
     writeFile "test/cassiuses/external2.cassius" "foo\n  #{var}: 1"
     -}
 
-  describe "cassiusOrd" $ do
+  describe "Ordered.cassius" $ do
     it "comments" $ do
       -- FIXME reconsider Hamlet comment syntax?
-      celper "" [cassiusOrd|/* this is a comment */
+      celper "" [Ordered.cassius|/* this is a comment */
 /* another comment */
 /*a third one*/|]
 
     it "pseudo-class" $
-      flip celper [cassiusOrd|
+      flip celper [Ordered.cassius|
 a:visited
     color: blue
 |] "a:visited{color:blue}"
 
 
     it "ignores a blank line" $ do
-      celper "foo{bar:baz}" [cassiusOrd|
+      celper "foo{bar:baz}" [Ordered.cassius|
 foo
 
     bar: baz
@@ -631,21 +740,21 @@ foo
 
 
     it "leading spaces" $
-      celper "foo{bar:baz}" [cassiusOrd|
+      celper "foo{bar:baz}" [Ordered.cassius|
   foo
     bar: baz
 |]
 
 
     it "all spaces" $
-      celper "h1{color:green }" [cassiusOrd|
+      celper "h1{color:green }" [Ordered.cassius|
     h1
         color: green 
     |]
 
 
     it "whitespace and colons" $ do
-      celper "h1:hover{color:green ;font-family:sans-serif}" [cassiusOrd|
+      celper "h1:hover{color:green ;font-family:sans-serif}" [Ordered.cassius|
     h1:hover
         color: green 
         font-family:sans-serif
@@ -653,7 +762,7 @@ foo
 
 
     it "trailing comments" $
-      celper "h1:hover{color:green ;font-family:sans-serif}" [cassiusOrd|
+      celper "h1:hover{color:green ;font-family:sans-serif}" [Ordered.cassius|
     h1:hover /* Please ignore this */
         color: green /* This is a comment. */
         /* Obviously this is ignored too. */
@@ -661,14 +770,14 @@ foo
     |]
 
     it "nesting" $
-      celper "foo bar{baz:bin}" [cassiusOrd|
+      celper "foo bar{baz:bin}" [Ordered.cassius|
     foo
         bar
             baz: bin
     |]
 
     it "variable" $
-      celper "foo bar{baz:bin}" [cassiusOrd|
+      celper "foo bar{baz:bin}" [Ordered.cassius|
     @binvar: bin
     foo
         bar
@@ -676,7 +785,7 @@ foo
     |]
 
     it "trailing semicolon" $
-      celper "foo bar{baz:bin}" [cassiusOrd|
+      celper "foo bar{baz:bin}" [Ordered.cassius|
     @binvar: bin
     foo
         bar
@@ -689,14 +798,14 @@ foo
           dub = 3.14::Double
           int = -5::Int
       celper "sel{bar:oof oof 3.14 -5}"
-        [cassiusOrd|
+        [Ordered.cassius|
 sel
     bar: #{Data.List.reverse foo} #{L.reverse foo} #{show dub} #{show int}
 |]
 
 
     it "single dollar at and caret" $ do
-      celper "sel{att:$@^}" [cassiusOrd|
+      celper "sel{att:$@^}" [Ordered.cassius|
 sel
     att: $@^
 |]
@@ -711,35 +820,35 @@ sel
 
     it "dollar operator" $ do
       let val = (1, (2, 3)) :: (Integer, (Integer, Integer))
-      celper "sel{att:2}" [cassiusOrd|
+      celper "sel{att:2}" [Ordered.cassius|
 sel
     att: #{ show $ fst $ snd val }
 |]
-      celper "sel{att:2}" [cassiusOrd|
+      celper "sel{att:2}" [Ordered.cassius|
 sel
     att: #{ show $ fst $ snd $ val}
 |]
 
 
     it "embedded slash" $ do
-      celper "sel{att:///}" [cassiusOrd|
+      celper "sel{att:///}" [Ordered.cassius|
 sel
     att: ///
 |]
 
 
     it "multi cassius" $ do
-      celper "foo{bar:baz;bar:bin}" [cassiusOrd|
+      celper "foo{bar:baz;bar:bin}" [Ordered.cassius|
 foo
     bar: baz
     bar: bin
 |]
 
-  describe "luciusOrd" $ do
+  describe "Ordered.lucius" $ do
     it "lucius" $ do
       let var = "var"
       let urlp = (Home, [(pack "p", pack "q")])
-      flip celper [luciusOrd|
+      flip celper [Ordered.lucius|
 foo {
     background: #{colorBlack};
     bar: baz;
@@ -764,7 +873,7 @@ bin {
     it "lucius file" $ do
       let var = "var"
       let urlp = (Home, [(pack "p", pack "q")])
-      flip celper $(luciusFileOrd "test/cassiuses/external1.lucius") $ concat
+      flip celper $(Ordered.luciusFile "test/cassiuses/external1.lucius") $ concat
           [ "foo{background:#000;bar:baz;color:#F00}"
           , "bin{"
           , "background-image:url(url);"
@@ -775,7 +884,7 @@ bin {
     it "lucius file debug" caseLuciusFileDebugOrd
 
     it "lucius nested" $ do
-      celper "foo bar{baz:bin}" $(luciusFileOrd "test/cassiuses/external-nested.lucius")
+      celper "foo bar{baz:bin}" $(Ordered.luciusFile "test/cassiuses/external-nested.lucius")
       celper "foo bar {\n    baz: bin;\n}\n" $(luciusFileDebug "test/cassiuses/external-nested.lucius")
       celper "foo bar{baz:bin}" [lucius|
         foo {
@@ -798,7 +907,7 @@ bin {
         , "#content ul{list-style:none;padding:0 5em}"
         , "#content ul li{padding:1em 0}"
         , "#content ul li a{color:#419a56;font-family:'TeXGyreHerosBold',helvetica,arial,sans-serif;font-weight:bold;text-transform:uppercase;white-space:nowrap}"
-        ]) [luciusOrd|
+        ]) [Ordered.lucius|
 @charset "utf-8";
 #content ul
 {
@@ -820,9 +929,9 @@ bin {
 |]
 
     it "lucius media" $ do
-      celper "@media only screen{foo bar{baz:bin}}" $(luciusFileOrd "test/cassiuses/external-media.lucius")
-      celper "@media only screen {\n    foo bar {\n        baz: bin;\n    }\n}\n" $(luciusFileDebugOrd "test/cassiuses/external-media.lucius")
-      celper "@media only screen{foo bar{baz:bin}}" [luciusOrd|
+      celper "@media only screen{foo bar{baz:bin}}" $(Ordered.luciusFile "test/cassiuses/external-media.lucius")
+      celper "@media only screen {\n    foo bar {\n        baz: bin;\n    }\n}\n" $(Ordered.luciusFileDebug "test/cassiuses/external-media.lucius")
+      celper "@media only screen{foo bar{baz:bin}}" [Ordered.lucius|
         @media only screen{
             foo {
                 bar {
@@ -833,9 +942,9 @@ bin {
         |]
 
     it "lucius supports" $ do
-      celper "@supports only screen{hana dul{set:net}}" $(luciusFileOrd "test/cassiuses/external-supports.lucius")
-      celper "@supports only screen {\n    hana dul {\n        set: net;\n    }\n}\n" $(luciusFileDebugOrd "test/cassiuses/external-supports.lucius")
-      celper "@supports only screen    {hana,dul{set:net;dasut:yeosut}}" [luciusOrd|
+      celper "@supports only screen{hana dul{set:net}}" $(Ordered.luciusFile "test/cassiuses/external-supports.lucius")
+      celper "@supports only screen {\n    hana dul {\n        set: net;\n    }\n}\n" $(Ordered.luciusFileDebug "test/cassiuses/external-supports.lucius")
+      celper "@supports only screen    {hana,dul{set:net;dasut:yeosut}}" [Ordered.lucius|
         @supports only screen    {
             hana, dul {
                 set: net;
@@ -853,7 +962,7 @@ bin {
       -}
 
     it "lucius trailing comments" $
-      celper "foo{bar:baz}" [luciusOrd|foo{bar:baz;}/* ignored*/|]
+      celper "foo{bar:baz}" [Ordered.lucius|foo{bar:baz;}/* ignored*/|]
 
     it "lucius variables" $ celper "foo{bar:baz}" [lucius|
 @myvar: baz;
@@ -870,57 +979,57 @@ foo {
 -->
 |]
     it "lucius @import statements" $
-      celper "@import url(\"bla.css\");" [luciusOrd|
+      celper "@import url(\"bla.css\");" [Ordered.lucius|
 @import url("bla.css");
 |]
     it "lucius simple escapes" $
-      celper "*{a:test}" [luciusOrd|
+      celper "*{a:test}" [Ordered.lucius|
 * {
   a: t\65 st;
 }
 |]
     it "lucius bounded escapes" $
-      celper "*{a:teft}" [luciusOrd|
+      celper "*{a:teft}" [Ordered.lucius|
 * {
   a: t\000065ft;
 }
 |]
     it "lucius case-insensitive keywords" $
-       celper "@media foo {}" [luciusOrd|
+       celper "@media foo {}" [Ordered.lucius|
 @MeDIa foo {
 }
 |]
     it "lucius @page statements" $
-       celper "@page :right{a:b;c:d}" [luciusOrd|
+       celper "@page :right{a:b;c:d}" [Ordered.lucius|
 @page :right {
 a:b;
 c:d;
 }
 |]
     it "lucius @font-face statements" $
-       celper "@font-face{a:b;c:d}" [luciusOrd|
+       celper "@font-face{a:b;c:d}" [Ordered.lucius|
 @font-face {
 a:b;
 c:d;
 }
 |]
-    it "lucius runtime" $ Right (T.pack "foo {\n    bar: baz;\n}\n") @=? luciusRTOrd (T.pack "foo { bar: #{myvar}}") [(TS.pack "myvar", TS.pack "baz")]
-    it "lucius runtime variables" $ Right (T.pack "foo {\n    bar: baz;\n}\n") @=? luciusRTOrd (T.pack "@dummy: dummy; @myvar: baz; @dummy2: dummy; foo { bar: #{myvar}}") []
+    it "lucius runtime" $ Right (T.pack "foo {\n    bar: baz;\n}\n") @=? Ordered.luciusRT (T.pack "foo { bar: #{myvar}}") [(TS.pack "myvar", TS.pack "baz")]
+    it "lucius runtime variables" $ Right (T.pack "foo {\n    bar: baz;\n}\n") @=? Ordered.luciusRT (T.pack "@dummy: dummy; @myvar: baz; @dummy2: dummy; foo { bar: #{myvar}}") []
     it "lucius whtiespace" $ Right (T.pack "@media foo {\n    bar {\n        baz: bin;\n        baz2: bin2;\n    }\n}\n")
-      @=? luciusRTOrd (T.pack "@media foo{bar{baz:bin;baz2:bin2}}") []
+      @=? Ordered.luciusRT (T.pack "@media foo{bar{baz:bin;baz2:bin2}}") []
     it "variables inside value" $
-        celper "foo{foo:XbarY}" [luciusOrd|
+        celper "foo{foo:XbarY}" [Ordered.lucius|
 @bar: bar;
 foo { foo:X#{bar}Y; }
 |]
     it "variables in media selector" $
-        celper "@media (max-width: 400px){foo{color:red}}" [luciusOrd|
+        celper "@media (max-width: 400px){foo{color:red}}" [Ordered.lucius|
 @mobileWidth: 400px;
 @media (max-width: #{mobileWidth}){ foo { color: red; } }
 |]
     -- note: this file format is window (CR;NL)
     it "variables in supports selector" $
-        celper "@supports ((perspective: 1px)\r\n           and (not (-webkit-overflow-scrolling: touch))) {html,body{overflow:hidden;height:100%}body{transform:translateZ(0px)}}" [luciusOrd|
+        celper "@supports ((perspective: 1px)\r\n           and (not (-webkit-overflow-scrolling: touch))) {html,body{overflow:hidden;height:100%}body{transform:translateZ(0px)}}" [Ordered.lucius|
 @perspectiveTestValue: 1px;
 @supports ((perspective: #{perspectiveTestValue})
            and (not (-webkit-overflow-scrolling: touch))) {
@@ -934,16 +1043,16 @@ foo { foo:X#{bar}Y; }
 }
 |]
     it "URLs in import" $ celper
-        "@import url(\"suburl\");" [luciusOrd|
+        "@import url(\"suburl\");" [Ordered.lucius|
 @import url("@{Sub SubUrl}");
 |]
     it "vars in charset" $ do
       let charset = "mycharset"
-      celper "@charset mycharset;" [luciusOrd|
+      celper "@charset mycharset;" [Ordered.lucius|
 @charset #{charset};
 |]
     it "keyframes" $ celper
-        "@keyframes mymove {from{top:0px}to{top:200px}}" [luciusOrd|
+        "@keyframes mymove {from{top:0px}to{top:200px}}" [Ordered.lucius|
 @keyframes mymove {
     from {
         top: 0px;
@@ -954,7 +1063,7 @@ foo { foo:X#{bar}Y; }
 }
 |]
     it "prefixed keyframes" $ celper
-        "@-webkit-keyframes mymove {from{top:0px}to{top:200px}}" [luciusOrd|
+        "@-webkit-keyframes mymove {from{top:0px}to{top:200px}}" [Ordered.lucius|
 @-webkit-keyframes mymove {
     from {
         top: 0px;
@@ -967,32 +1076,27 @@ foo { foo:X#{bar}Y; }
 
   describe "ordered mixins" $ do
     it "lucius mixins" $ do
-        let bins = [luciusMixinOrd|
+        let bins = [Ordered.luciusMixin|
                    bin:bin2;
-                   /* FIXME not currently implementing sublocks in mixins
                    foo2 {
-                       x: y
-                   }
-                   */
+                        x: y;
+                    }
                    |] :: Mixin
-        -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
-        celper "foo{bar:baz;bin:bin2}" [luciusOrd|
+
+        celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [Ordered.lucius|
             foo {
                 bar: baz;
                 ^{bins}
             }
         |]
     it "lucius mixins keep order" $ do
-        let bins = [luciusMixinOrd|
+        let bins = [Ordered.luciusMixin|
                    bin:bin2;
-                   /* FIXME not currently implementing sublocks in mixins
                    foo2 {
-                       x: y
+                       x: y;
                    }
-                   */
                    |] :: Mixin
-        -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
-        celper "foo{bar1:baz1;bin:bin2;bar2:baz2}" [luciusOrd|
+        celper "foo{bar1:baz1;bin:bin2;bar2:baz2}foo foo2{x:y}" [Ordered.lucius|
             foo {
                 bar1:baz1;
                 ^{bins}
@@ -1001,16 +1105,16 @@ foo { foo:X#{bar}Y; }
         |]
 
     it "lucius nested mixins" $ do
-        let bins = [luciusMixinOrd|
+        let bins = [Ordered.luciusMixin|
                    bin:bin2;
                    bin3:bin4;
                    |] :: Mixin
-            bams = [luciusMixinOrd|
+            bams = [Ordered.luciusMixin|
                    bam:bam2;
                    ^{bins}
                    bam3:bam4;
                    |] :: Mixin
-        celper "foo{bar:bar2;bam:bam2;bin:bin2;bin3:bin4;bam3:bam4;bar3:bar4}" [luciusOrd|
+        celper "foo{bar:bar2;bam:bam2;bin:bin2;bin3:bin4;bam3:bam4;bar3:bar4}" [Ordered.lucius|
             foo {
                 bar:bar2;
                 ^{bams}
@@ -1019,12 +1123,12 @@ foo { foo:X#{bar}Y; }
         |]
 
     it "cassius mixins" $ do
-        let bins = [cassiusMixinOrd|
+        let bins = [Ordered.cassiusMixin|
                    bin:bin2
                    bin3:bin4
                    |] :: Mixin
         -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
-        celper "foo{bar:baz;bin:bin2;bin3:bin4}" [luciusOrd|
+        celper "foo{bar:baz;bin:bin2;bin3:bin4}" [Ordered.lucius|
             foo {
                 bar: baz;
                 ^{bins}
@@ -1032,12 +1136,12 @@ foo { foo:X#{bar}Y; }
         |]
 
     it "cassius mixins keep order" $ do
-        let bins = [cassiusMixinOrd|
+        let bins = [Ordered.cassiusMixin|
                    bin:bin2
                    bin3:bin4
                    |] :: Mixin
         -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
-        celper "foo{bar1:baz1;bin:bin2;bin3:bin4;bar2:baz2}" [luciusOrd|
+        celper "foo{bar1:baz1;bin:bin2;bin3:bin4;bar2:baz2}" [Ordered.lucius|
             foo {
                 bar1: baz1;
                 ^{bins}
@@ -1046,16 +1150,16 @@ foo { foo:X#{bar}Y; }
         |]
 
     it "cassius nested mixins" $ do
-        let bins = [cassiusMixinOrd|
+        let bins = [Ordered.cassiusMixin|
                    bin:bin2
                    bin3:bin4
                    |] :: Mixin
-            bams = [cassiusMixinOrd|
+            bams = [Ordered.cassiusMixin|
                    bam:bam2
                    ^{bins}
                    bam3:bam4
                    |] :: Mixin
-        celper "foo{bar:bar2;bam:bam2;bin:bin2;bin3:bin4;bam3:bam4;bar3:bar4}" [luciusOrd|
+        celper "foo{bar:bar2;bam:bam2;bin:bin2;bin3:bin4;bam3:bam4;bar3:bar4}" [Ordered.lucius|
             foo {
                 bar:bar2;
                 ^{bams}
@@ -1065,7 +1169,7 @@ foo { foo:X#{bar}Y; }
 
     it "more complicated mixins" $ do
         let transition val =
-                [luciusMixinOrd|
+                [Ordered.luciusMixin|
                     -webkit-transition: #{val};
                     -moz-transition: #{val};
                     -ms-transition: #{val};
@@ -1074,41 +1178,174 @@ foo { foo:X#{bar}Y; }
                 |]
 
         celper ".some-class{-webkit-transition:all 4s ease;-moz-transition:all 4s ease;-ms-transition:all 4s ease;-o-transition:all 4s ease;transition:all 4s ease}"
-                [luciusOrd|
+                [Ordered.lucius|
                     .some-class {
                         ^{transition "all 4s ease"}
                     }
                 |]
 
+    it "nested mixin blocks" $ do
+        let bar = [Ordered.luciusMixin|
+                    bar {
+                        bin:baz;
+                    }
+                  |]
+            foo = [luciusMixin|
+                    foo {
+                        ^{bar}
+                    }
+                  |] :: Mixin
+        celper "selector foo bar{bin:baz}" [Ordered.lucius|
+            selector {
+                ^{foo}
+            }
+        |]
+
+    it "mixins with pseudoselectors" $ do
+        let bar = [Ordered.luciusMixin|
+                    &:hover {
+                        bin:baz;
+                    }
+                  |] :: Mixin
+        celper "foo:hover{bin:baz}" [Ordered.lucius|
+            foo {
+                ^{bar}
+            }
+        |]
+
+    it "mixins insane structure" $ do
+        let bar = [Ordered.luciusMixin|
+                    bar1:bar2;
+                    ^{bim}
+                    &:hover {
+                        ^{bim}
+                        jam1:jam2;
+                        ^{bam}
+                    }
+                    
+                    ram {
+                        ^{bim}
+                        ram1:ram2;
+                        ^{bam}
+                    }
+                    ^{bam}
+                    bar3:bar4;
+                  |] :: Mixin
+            bim = [Ordered.luciusMixin|
+                    bim1:bim2;
+                    bim-block1 {
+                      bim3:bim4;
+                      bim5:bim6;
+                    }
+                    bim-block2 {
+                      bim7:bim8;
+                      bim9:bim10;
+                    }
+                  |]
+            bam = [Ordered.luciusMixin|
+                    bam1:bam2;
+                    bam-block1 {
+                      bam3:bam4;
+                      bam5:bam6;
+                    }
+                    bam-block2 {
+                      bam7:bam8;
+                      bam9:bam10;
+                    }
+                  |]
+                  
+        celper
+            -- 1. ordered attributes and mixins attributes 
+            -- 2. blocks
+            -- 3. mixins blocks
+            "foo{foo1:foo2;bar1:bar2;bim1:bim2;bam1:bam2;bar3:bar4;foo3:foo4}\
+
+            \foo foo-block1{bar1:bar2;bim1:bim2;bam1:bam2;bar3:bar4}\
+            \foo foo-block1:hover{bim1:bim2;jam1:jam2;bam1:bam2}\
+            \foo foo-block1:hover bim-block1{bim3:bim4;bim5:bim6}\
+            \foo foo-block1:hover bim-block2{bim7:bim8;bim9:bim10}\
+            \foo foo-block1:hover bam-block1{bam3:bam4;bam5:bam6}\
+            \foo foo-block1:hover bam-block2{bam7:bam8;bam9:bam10}\
+            \foo foo-block1 ram{bim1:bim2;ram1:ram2;bam1:bam2}\
+            \foo foo-block1 ram bim-block1{bim3:bim4;bim5:bim6}\
+            \foo foo-block1 ram bim-block2{bim7:bim8;bim9:bim10}\
+            \foo foo-block1 ram bam-block1{bam3:bam4;bam5:bam6}\
+            \foo foo-block1 ram bam-block2{bam7:bam8;bam9:bam10}\
+            \foo foo-block1 bim-block1{bim3:bim4;bim5:bim6}\
+            \foo foo-block1 bim-block2{bim7:bim8;bim9:bim10}\
+            \foo foo-block1 bam-block1{bam3:bam4;bam5:bam6}\
+            \foo foo-block1 bam-block2{bam7:bam8;bam9:bam10}\
+
+            \foo foo-block2{bar1:bar2;bim1:bim2;bam1:bam2;bar3:bar4}\
+            \foo foo-block2:hover{bim1:bim2;jam1:jam2;bam1:bam2}\
+            \foo foo-block2:hover bim-block1{bim3:bim4;bim5:bim6}\
+            \foo foo-block2:hover bim-block2{bim7:bim8;bim9:bim10}\
+            \foo foo-block2:hover bam-block1{bam3:bam4;bam5:bam6}\
+            \foo foo-block2:hover bam-block2{bam7:bam8;bam9:bam10}\
+            \foo foo-block2 ram{bim1:bim2;ram1:ram2;bam1:bam2}\
+            \foo foo-block2 ram bim-block1{bim3:bim4;bim5:bim6}\
+            \foo foo-block2 ram bim-block2{bim7:bim8;bim9:bim10}\
+            \foo foo-block2 ram bam-block1{bam3:bam4;bam5:bam6}\
+            \foo foo-block2 ram bam-block2{bam7:bam8;bam9:bam10}\
+            \foo foo-block2 bim-block1{bim3:bim4;bim5:bim6}\
+            \foo foo-block2 bim-block2{bim7:bim8;bim9:bim10}\
+            \foo foo-block2 bam-block1{bam3:bam4;bam5:bam6}\
+            \foo foo-block2 bam-block2{bam7:bam8;bam9:bam10}\
+
+            \foo:hover{bim1:bim2;jam1:jam2;bam1:bam2}\
+            \foo:hover bim-block1{bim3:bim4;bim5:bim6}\
+            \foo:hover bim-block2{bim7:bim8;bim9:bim10}\
+            \foo:hover bam-block1{bam3:bam4;bam5:bam6}\
+            \foo:hover bam-block2{bam7:bam8;bam9:bam10}\
+            \foo ram{bim1:bim2;ram1:ram2;bam1:bam2}\
+            \foo ram bim-block1{bim3:bim4;bim5:bim6}\
+            \foo ram bim-block2{bim7:bim8;bim9:bim10}\
+            \foo ram bam-block1{bam3:bam4;bam5:bam6}\
+            \foo ram bam-block2{bam7:bam8;bam9:bam10}\
+            \foo bim-block1{bim3:bim4;bim5:bim6}\
+            \foo bim-block2{bim7:bim8;bim9:bim10}\
+            \foo bam-block1{bam3:bam4;bam5:bam6}\
+            \foo bam-block2{bam7:bam8;bam9:bam10}"
+            [Ordered.lucius|
+                foo {
+                    foo1:foo2;
+                    ^{bar}
+                    foo-block1 {
+                        ^{bar}
+                    }
+                    foo-block2 {
+                        ^{bar}
+                    }
+                    foo3:foo4;
+                }
+            |]
+
     it "runtime mixin" $ do
-        let bins = [luciusMixinOrd|
+        let bins = [Ordered.luciusMixin|
                    bin:bin2;
-                   /* FIXME not currently implementing sublocks in mixins
                    foo2 {
-                       x: y
+                       x: y;
                    }
-                   */
                    |] :: Mixin
-        -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
-        Right (T.pack "foo{bar:baz;bin:bin2}") @=? luciusRTMixinOrd
+        Right (T.pack "foo{bar:baz;bin:bin2}foo foo2{x:y}") @=? Ordered.luciusRTMixin
             (T.pack "foo { bar: baz; ^{bins} }")
             True
             [(TS.pack "bins", RTVMixin bins)]
 
     it "luciusFileReload mixin" $ do
-      let mixin = [luciusMixinOrd|foo:bar;baz:bin|]
-      flip celper $(luciusFileReloadOrd "test/cassiuses/mixin.lucius") $ concat
+      let mixin = [Ordered.luciusMixin|foo:bar;baz:bin|]
+      flip celper $(Ordered.luciusFileReload "test/cassiuses/mixin.lucius") $ concat
           [ "selector {\n    foo: bar;\n    baz: bin;\n}\n"
           ]
 
     it "cassiusFileReload with import URL" $ do
       celper
         "@import url(url);\n"
-        $(cassiusFileReloadOrd "test/cassiuses/reload-import.cassius")
+        $(Ordered.cassiusFileReload "test/cassiuses/reload-import.cassius")
 
     it "& subblocks" $
         celper "foo:bar{baz:bin}"
-        [luciusOrd|
+        [Ordered.lucius|
             foo {
                 &:bar {
                     baz: bin;
@@ -1119,7 +1356,7 @@ foo { foo:X#{bar}Y; }
     describe "font-face #139" $ do
         it "lucius" $
             celper "@font-face{font-family:myFirstFont;src:url(sansation_light.woff)}"
-            [luciusOrd|
+            [Ordered.lucius|
                 @font-face {
                     font-family: myFirstFont;
                     src: url(sansation_light.woff);
@@ -1127,23 +1364,23 @@ foo { foo:X#{bar}Y; }
             |]
         it "cassius" $
             celper "@font-face{font-family:myFirstFont;src:url(sansation_light.woff)}"
-            [cassiusOrd|
+            [Ordered.cassius|
                 @font-face
                     font-family: myFirstFont
                     src: url(sansation_light.woff)
             |]
 
     describe "trailing semicolon in mixin" $ do
-        let someMixin = [luciusMixinOrd|foo:bar|]
+        let someMixin = [Ordered.luciusMixin|foo:bar|]
         it "direct in lucius" $
-            celper "baz{foo:bar}" [luciusOrd|
+            celper "baz{foo:bar}" [Ordered.lucius|
                 baz {
                     ^{someMixin};
                 }
             |]
 
         it "implicit in cassius #194" $
-            celper "baz{foo:bar}" [cassiusOrd|
+            celper "baz{foo:bar}" [Ordered.cassius|
                 baz
                     ^{someMixin}
             |]
@@ -1220,7 +1457,7 @@ caseCassiusOrd :: Assertion
 caseCassiusOrd = do
     let var = "var"
     let urlp = (Home, [(pack "p", pack "q")])
-    flip celper [cassiusOrd|
+    flip celper [Ordered.cassius|
 foo
     background: #{colorBlack}
     bar: baz
@@ -1258,7 +1495,7 @@ caseCassiusFileOrd = do
     let var = "var"
     let selector = "foo"
     let urlp = (Home, [(pack "p", pack "q")])
-    flip celper $(cassiusFileOrd "test/cassiuses/external1.cassius") $ concat
+    flip celper $(Ordered.cassiusFile "test/cassiuses/external1.cassius") $ concat
         [ "foo{background:#000;bar:baz;color:#F00}"
         , "bin{"
         , "background-image:url(url);"
@@ -1276,7 +1513,7 @@ caseCassiusSingleComment =
 
 caseCassiusSingleCommentOrd :: Assertion
 caseCassiusSingleCommentOrd =
-    flip celper [cassiusOrd|
+    flip celper [Ordered.cassius|
         /*
         this is a comment
         */
@@ -1296,7 +1533,7 @@ caseCassiusLeadingComment =
 
 caseCassiusLeadingCommentOrd :: Assertion
 caseCassiusLeadingCommentOrd =
-    flip celper [cassiusOrd|
+    flip celper [Ordered.cassius|
         /*
         this is a comment
         */
@@ -1323,7 +1560,7 @@ caseLuciusFileDebugOrd :: Assertion
 caseLuciusFileDebugOrd = do
     let var = "var"
     writeFile "test/cassiuses/external2.lucius" "foo{#{var}: 1}"
-    celper "foo {\n    var: 1;\n}\n" $(luciusFileDebugOrd "test/cassiuses/external2.lucius")
+    celper "foo {\n    var: 1;\n}\n" $(Ordered.luciusFileDebug "test/cassiuses/external2.lucius")
     writeFile "test/cassiuses/external2.lucius" "foo{#{var}: 2}"
-    celper "foo {\n    var: 2;\n}\n" $(luciusFileDebugOrd "test/cassiuses/external2.lucius")
+    celper "foo {\n    var: 2;\n}\n" $(Ordered.luciusFileDebug "test/cassiuses/external2.lucius")
     writeFile "test/cassiuses/external2.lucius" "foo{#{var}: 1}"

--- a/test/Text/CssSpec.hs
+++ b/test/Text/CssSpec.hs
@@ -452,6 +452,23 @@ foo { foo:X#{bar}Y; }
                 ^{bins}
             }
         |]
+    it "cassius mixins keep order" $ do
+        let bins = [cassiusMixin|
+                   bin:bin2
+                   bin3:bin4
+                   |] :: Mixin
+            bams = [cassiusMixin|
+                   bam:bam2
+                   ^{bins}
+                   bam3:bam4
+                   |] :: Mixin
+        celper "foo{bam:bam2;bin:bin2;bin3:bin4;bam3:bam4;bar:baz}" [lucius|
+            foo {
+                ^{bams}
+                bar: baz;
+            }
+        |]
+
     it "more complicated mixins" $ do
         let transition val =
                 [luciusMixin|

--- a/test/Text/CssSpec.hs
+++ b/test/Text/CssSpec.hs
@@ -19,6 +19,7 @@ import Data.Monoid (mappend)
 
 spec :: Spec
 spec = do
+  describe "Unordered parsers" $ do
     it "cassius" caseCassius
     it "cassiusFile" caseCassiusFile
     it "cassius single comment" caseCassiusSingleComment
@@ -47,12 +48,11 @@ spec = do
     -}
 
 
-    it "comments" $ do
+    it "cassius comments" $ do
       -- FIXME reconsider Hamlet comment syntax?
       celper "" [cassius|/* this is a comment */
 /* another comment */
 /*a third one*/|]
-
 
     it "cassius pseudo-class" $
       flip celper [cassius|
@@ -452,7 +452,7 @@ foo { foo:X#{bar}Y; }
                 ^{bins}
             }
         |]
-    it "cassius mixins keep order" $ do
+    it "cassius nested mixins" $ do
         let bins = [cassiusMixin|
                    bin:bin2
                    bin3:bin4
@@ -462,7 +462,7 @@ foo { foo:X#{bar}Y; }
                    ^{bins}
                    bam3:bam4
                    |] :: Mixin
-        celper "foo{bam:bam2;bin:bin2;bin3:bin4;bam3:bam4;bar:baz}" [lucius|
+        celper "foo{bar:baz;bam:bam2;bam3:bam4;bin:bin2;bin3:bin4}" [lucius|
             foo {
                 ^{bams}
                 bar: baz;
@@ -554,6 +554,575 @@ foo { foo:X#{bar}Y; }
                     ^{someMixin}
             |]
 
+  describe "Ordered parsers" $ do
+    it "cassiusOrd" caseCassiusOrd
+    it "cassiusFileOrd" caseCassiusFileOrd
+    it "cassiusOrd single comment" caseCassiusSingleCommentOrd
+    it "cassiusOrd leading comment" caseCassiusLeadingCommentOrd
+
+    it "cassiusFileDebugOrd" $ do
+      let var = "var"
+      let selector = "foo"
+      let urlp = (Home, [(pack "p", pack "q")])
+      flip celper $(cassiusFileDebugOrd "test/cassiuses/external1.cassius") $ concat
+          [ "foo {\n    background: #000;\n    bar: baz;\n    color: #F00;\n}\n"
+          , "bin {\n"
+          , "    background-image: url(url);\n"
+          , "    bar: bar;\n    color: #7F6405;\n    fvarx: someval;\n    unicode-test: שלום;\n"
+          , "    urlp: url(url?p=q);\n}\n"
+          ]
+
+{- TODO
+    it "cassiusFileDebugChange" $ do
+    let var = "var"
+    writeFile "test/cassiuses/external2.cassius" "foo\n  #{var}: 1"
+    celper "foo{var:1}" $(cassiusFileDebug "test/cassiuses/external2.cassius")
+    writeFile "test/cassiuses/external2.cassius" "foo\n  #{var}: 2"
+    celper "foo{var:2}" $(cassiusFileDebug "test/cassiuses/external2.cassius")
+    writeFile "test/cassiuses/external2.cassius" "foo\n  #{var}: 1"
+    -}
+
+  describe "cassiusOrd" $ do
+    it "comments" $ do
+      -- FIXME reconsider Hamlet comment syntax?
+      celper "" [cassiusOrd|/* this is a comment */
+/* another comment */
+/*a third one*/|]
+
+    it "pseudo-class" $
+      flip celper [cassiusOrd|
+a:visited
+    color: blue
+|] "a:visited{color:blue}"
+
+
+    it "ignores a blank line" $ do
+      celper "foo{bar:baz}" [cassiusOrd|
+foo
+
+    bar: baz
+
+|]
+
+
+    it "leading spaces" $
+      celper "foo{bar:baz}" [cassiusOrd|
+  foo
+    bar: baz
+|]
+
+
+    it "all spaces" $
+      celper "h1{color:green }" [cassiusOrd|
+    h1
+        color: green 
+    |]
+
+
+    it "whitespace and colons" $ do
+      celper "h1:hover{color:green ;font-family:sans-serif}" [cassiusOrd|
+    h1:hover
+        color: green 
+        font-family:sans-serif
+    |]
+
+
+    it "trailing comments" $
+      celper "h1:hover{color:green ;font-family:sans-serif}" [cassiusOrd|
+    h1:hover /* Please ignore this */
+        color: green /* This is a comment. */
+        /* Obviously this is ignored too. */
+        font-family:sans-serif
+    |]
+
+    it "nesting" $
+      celper "foo bar{baz:bin}" [cassiusOrd|
+    foo
+        bar
+            baz: bin
+    |]
+
+    it "variable" $
+      celper "foo bar{baz:bin}" [cassiusOrd|
+    @binvar: bin
+    foo
+        bar
+            baz: #{binvar}
+    |]
+
+    it "trailing semicolon" $
+      celper "foo bar{baz:bin}" [cassiusOrd|
+    @binvar: bin
+    foo
+        bar
+            baz: #{binvar};
+    |]
+
+
+    it "module names" $ do
+      let foo = "foo"
+          dub = 3.14::Double
+          int = -5::Int
+      celper "sel{bar:oof oof 3.14 -5}"
+        [cassiusOrd|
+sel
+    bar: #{Data.List.reverse foo} #{L.reverse foo} #{show dub} #{show int}
+|]
+
+
+    it "single dollar at and caret" $ do
+      celper "sel{att:$@^}" [cassiusOrd|
+sel
+    att: $@^
+|]
+
+  {-
+      celper "sel{att:#{@{^{}" [cassius|
+sel
+    att: #\{@\{^{
+|]
+-}
+
+
+    it "dollar operator" $ do
+      let val = (1, (2, 3)) :: (Integer, (Integer, Integer))
+      celper "sel{att:2}" [cassiusOrd|
+sel
+    att: #{ show $ fst $ snd val }
+|]
+      celper "sel{att:2}" [cassiusOrd|
+sel
+    att: #{ show $ fst $ snd $ val}
+|]
+
+
+    it "embedded slash" $ do
+      celper "sel{att:///}" [cassiusOrd|
+sel
+    att: ///
+|]
+
+
+    it "multi cassius" $ do
+      celper "foo{bar:baz;bar:bin}" [cassiusOrd|
+foo
+    bar: baz
+    bar: bin
+|]
+
+  describe "luciusOrd" $ do
+    it "lucius" $ do
+      let var = "var"
+      let urlp = (Home, [(pack "p", pack "q")])
+      flip celper [luciusOrd|
+foo {
+    background: #{colorBlack};
+    bar: baz;
+    color: #{colorRed};
+}
+bin {
+        background-image: url(@{Home});
+        bar: bar;
+        color: #{(((Color 127) 100) 5)};
+        f#{var}x: someval;
+        unicode-test: שלום;
+        urlp: url(@?{urlp});
+}
+|] $ concat
+        [ "foo{background:#000;bar:baz;color:#F00}"
+        , "bin{"
+        , "background-image:url(url);"
+        , "bar:bar;color:#7F6405;fvarx:someval;unicode-test:שלום;"
+        , "urlp:url(url?p=q)}"
+        ]
+
+    it "lucius file" $ do
+      let var = "var"
+      let urlp = (Home, [(pack "p", pack "q")])
+      flip celper $(luciusFileOrd "test/cassiuses/external1.lucius") $ concat
+          [ "foo{background:#000;bar:baz;color:#F00}"
+          , "bin{"
+          , "background-image:url(url);"
+          , "bar:bar;color:#7F6405;fvarx:someval;unicode-test:שלום;"
+          , "urlp:url(url?p=q)}"
+          ]
+
+    it "lucius file debug" caseLuciusFileDebugOrd
+
+    it "lucius nested" $ do
+      celper "foo bar{baz:bin}" $(luciusFileOrd "test/cassiuses/external-nested.lucius")
+      celper "foo bar {\n    baz: bin;\n}\n" $(luciusFileDebug "test/cassiuses/external-nested.lucius")
+      celper "foo bar{baz:bin}" [lucius|
+        foo {
+            bar {
+                baz: bin;
+            }
+        }
+        |]
+      celper "foo1 bar,foo2 bar{baz:bin}" [lucius|
+        foo1, foo2 {
+            bar {
+                baz: bin;
+            }
+        }
+        |]
+
+
+    it "lucius charset" $ do
+      celper (concat ["@charset \"utf-8\";"
+        , "#content ul{list-style:none;padding:0 5em}"
+        , "#content ul li{padding:1em 0}"
+        , "#content ul li a{color:#419a56;font-family:'TeXGyreHerosBold',helvetica,arial,sans-serif;font-weight:bold;text-transform:uppercase;white-space:nowrap}"
+        ]) [luciusOrd|
+@charset "utf-8";
+#content ul
+{
+    list-style: none;
+    padding: 0 5em;
+    li
+    {
+        padding: 1em 0;
+        a
+        {
+            color: #419a56;
+            font-family: 'TeXGyreHerosBold',helvetica,arial,sans-serif;
+            font-weight: bold;
+            text-transform: uppercase;
+            white-space: nowrap;
+        }
+    }
+}
+|]
+
+    it "lucius media" $ do
+      celper "@media only screen{foo bar{baz:bin}}" $(luciusFileOrd "test/cassiuses/external-media.lucius")
+      celper "@media only screen {\n    foo bar {\n        baz: bin;\n    }\n}\n" $(luciusFileDebugOrd "test/cassiuses/external-media.lucius")
+      celper "@media only screen{foo bar{baz:bin}}" [luciusOrd|
+        @media only screen{
+            foo {
+                bar {
+                    baz: bin;
+                }
+            }
+        }
+        |]
+
+    it "lucius supports" $ do
+      celper "@supports only screen{hana dul{set:net}}" $(luciusFileOrd "test/cassiuses/external-supports.lucius")
+      celper "@supports only screen {\n    hana dul {\n        set: net;\n    }\n}\n" $(luciusFileDebugOrd "test/cassiuses/external-supports.lucius")
+      celper "@supports only screen    {hana,dul{set:net;dasut:yeosut}}" [luciusOrd|
+        @supports only screen    {
+            hana, dul {
+                set: net;
+                dasut: yeosut;
+            }
+        }
+        |]
+
+    {-
+    it "cassius removes whitespace" $ do
+      celper "foo{bar:baz}" [cassius|
+      foo
+          bar     :    baz
+      |]
+      -}
+
+    it "lucius trailing comments" $
+      celper "foo{bar:baz}" [luciusOrd|foo{bar:baz;}/* ignored*/|]
+
+    it "lucius variables" $ celper "foo{bar:baz}" [lucius|
+@myvar: baz;
+foo {
+    bar: #{myvar};
+}
+|]
+    it "lucius CDO/CDC tokens" $
+       celper "*{a:b}" [lucius|
+<!-- --> <!--
+* {
+  a: b;
+}
+-->
+|]
+    it "lucius @import statements" $
+      celper "@import url(\"bla.css\");" [luciusOrd|
+@import url("bla.css");
+|]
+    it "lucius simple escapes" $
+      celper "*{a:test}" [luciusOrd|
+* {
+  a: t\65 st;
+}
+|]
+    it "lucius bounded escapes" $
+      celper "*{a:teft}" [luciusOrd|
+* {
+  a: t\000065ft;
+}
+|]
+    it "lucius case-insensitive keywords" $
+       celper "@media foo {}" [luciusOrd|
+@MeDIa foo {
+}
+|]
+    it "lucius @page statements" $
+       celper "@page :right{a:b;c:d}" [luciusOrd|
+@page :right {
+a:b;
+c:d;
+}
+|]
+    it "lucius @font-face statements" $
+       celper "@font-face{a:b;c:d}" [luciusOrd|
+@font-face {
+a:b;
+c:d;
+}
+|]
+    it "lucius runtime" $ Right (T.pack "foo {\n    bar: baz;\n}\n") @=? luciusRTOrd (T.pack "foo { bar: #{myvar}}") [(TS.pack "myvar", TS.pack "baz")]
+    it "lucius runtime variables" $ Right (T.pack "foo {\n    bar: baz;\n}\n") @=? luciusRTOrd (T.pack "@dummy: dummy; @myvar: baz; @dummy2: dummy; foo { bar: #{myvar}}") []
+    it "lucius whtiespace" $ Right (T.pack "@media foo {\n    bar {\n        baz: bin;\n        baz2: bin2;\n    }\n}\n")
+      @=? luciusRTOrd (T.pack "@media foo{bar{baz:bin;baz2:bin2}}") []
+    it "variables inside value" $
+        celper "foo{foo:XbarY}" [luciusOrd|
+@bar: bar;
+foo { foo:X#{bar}Y; }
+|]
+    it "variables in media selector" $
+        celper "@media (max-width: 400px){foo{color:red}}" [luciusOrd|
+@mobileWidth: 400px;
+@media (max-width: #{mobileWidth}){ foo { color: red; } }
+|]
+    -- note: this file format is window (CR;NL)
+    it "variables in supports selector" $
+        celper "@supports ((perspective: 1px)\r\n           and (not (-webkit-overflow-scrolling: touch))) {html,body{overflow:hidden;height:100%}body{transform:translateZ(0px)}}" [luciusOrd|
+@perspectiveTestValue: 1px;
+@supports ((perspective: #{perspectiveTestValue})
+           and (not (-webkit-overflow-scrolling: touch))) {
+    html, body {
+        overflow: hidden;
+        height:100%;
+    }
+    body {
+        transform: translateZ(0px);
+    }
+}
+|]
+    it "URLs in import" $ celper
+        "@import url(\"suburl\");" [luciusOrd|
+@import url("@{Sub SubUrl}");
+|]
+    it "vars in charset" $ do
+      let charset = "mycharset"
+      celper "@charset mycharset;" [luciusOrd|
+@charset #{charset};
+|]
+    it "keyframes" $ celper
+        "@keyframes mymove {from{top:0px}to{top:200px}}" [luciusOrd|
+@keyframes mymove {
+    from {
+        top: 0px;
+    }
+    to {
+        top: 200px;
+    }
+}
+|]
+    it "prefixed keyframes" $ celper
+        "@-webkit-keyframes mymove {from{top:0px}to{top:200px}}" [luciusOrd|
+@-webkit-keyframes mymove {
+    from {
+        top: 0px;
+    }
+    to {
+        top: 200px;
+    }
+}
+|]
+
+  describe "ordered mixins" $ do
+    it "lucius mixins" $ do
+        let bins = [luciusMixinOrd|
+                   bin:bin2;
+                   /* FIXME not currently implementing sublocks in mixins
+                   foo2 {
+                       x: y
+                   }
+                   */
+                   |] :: Mixin
+        -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
+        celper "foo{bar:baz;bin:bin2}" [luciusOrd|
+            foo {
+                bar: baz;
+                ^{bins}
+            }
+        |]
+    it "lucius mixins keep order" $ do
+        let bins = [luciusMixinOrd|
+                   bin:bin2;
+                   /* FIXME not currently implementing sublocks in mixins
+                   foo2 {
+                       x: y
+                   }
+                   */
+                   |] :: Mixin
+        -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
+        celper "foo{bar1:baz1;bin:bin2;bar2:baz2}" [luciusOrd|
+            foo {
+                bar1:baz1;
+                ^{bins}
+                bar2: baz2;
+            }
+        |]
+
+    it "lucius nested mixins" $ do
+        let bins = [luciusMixinOrd|
+                   bin:bin2;
+                   bin3:bin4;
+                   |] :: Mixin
+            bams = [luciusMixinOrd|
+                   bam:bam2;
+                   ^{bins}
+                   bam3:bam4;
+                   |] :: Mixin
+        celper "foo{bar:bar2;bam:bam2;bin:bin2;bin3:bin4;bam3:bam4;bar3:bar4}" [luciusOrd|
+            foo {
+                bar:bar2;
+                ^{bams}
+                bar3: bar4;
+            }
+        |]
+
+    it "cassius mixins" $ do
+        let bins = [cassiusMixinOrd|
+                   bin:bin2
+                   bin3:bin4
+                   |] :: Mixin
+        -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
+        celper "foo{bar:baz;bin:bin2;bin3:bin4}" [luciusOrd|
+            foo {
+                bar: baz;
+                ^{bins}
+            }
+        |]
+
+    it "cassius mixins keep order" $ do
+        let bins = [cassiusMixinOrd|
+                   bin:bin2
+                   bin3:bin4
+                   |] :: Mixin
+        -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
+        celper "foo{bar1:baz1;bin:bin2;bin3:bin4;bar2:baz2}" [luciusOrd|
+            foo {
+                bar1: baz1;
+                ^{bins}
+                bar2:baz2;
+            }
+        |]
+
+    it "cassius nested mixins" $ do
+        let bins = [cassiusMixinOrd|
+                   bin:bin2
+                   bin3:bin4
+                   |] :: Mixin
+            bams = [cassiusMixinOrd|
+                   bam:bam2
+                   ^{bins}
+                   bam3:bam4
+                   |] :: Mixin
+        celper "foo{bar:bar2;bam:bam2;bin:bin2;bin3:bin4;bam3:bam4;bar3:bar4}" [luciusOrd|
+            foo {
+                bar:bar2;
+                ^{bams}
+                bar3: bar4;
+            }
+        |]
+
+    it "more complicated mixins" $ do
+        let transition val =
+                [luciusMixinOrd|
+                    -webkit-transition: #{val};
+                    -moz-transition: #{val};
+                    -ms-transition: #{val};
+                    -o-transition: #{val};
+                    transition: #{val};
+                |]
+
+        celper ".some-class{-webkit-transition:all 4s ease;-moz-transition:all 4s ease;-ms-transition:all 4s ease;-o-transition:all 4s ease;transition:all 4s ease}"
+                [luciusOrd|
+                    .some-class {
+                        ^{transition "all 4s ease"}
+                    }
+                |]
+
+    it "runtime mixin" $ do
+        let bins = [luciusMixinOrd|
+                   bin:bin2;
+                   /* FIXME not currently implementing sublocks in mixins
+                   foo2 {
+                       x: y
+                   }
+                   */
+                   |] :: Mixin
+        -- No sublocks celper "foo{bar:baz;bin:bin2}foo foo2{x:y}" [lucius|
+        Right (T.pack "foo{bar:baz;bin:bin2}") @=? luciusRTMixinOrd
+            (T.pack "foo { bar: baz; ^{bins} }")
+            True
+            [(TS.pack "bins", RTVMixin bins)]
+
+    it "luciusFileReload mixin" $ do
+      let mixin = [luciusMixinOrd|foo:bar;baz:bin|]
+      flip celper $(luciusFileReloadOrd "test/cassiuses/mixin.lucius") $ concat
+          [ "selector {\n    foo: bar;\n    baz: bin;\n}\n"
+          ]
+
+    it "cassiusFileReload with import URL" $ do
+      celper
+        "@import url(url);\n"
+        $(cassiusFileReloadOrd "test/cassiuses/reload-import.cassius")
+
+    it "& subblocks" $
+        celper "foo:bar{baz:bin}"
+        [luciusOrd|
+            foo {
+                &:bar {
+                    baz: bin;
+                }
+            }
+        |]
+
+    describe "font-face #139" $ do
+        it "lucius" $
+            celper "@font-face{font-family:myFirstFont;src:url(sansation_light.woff)}"
+            [luciusOrd|
+                @font-face {
+                    font-family: myFirstFont;
+                    src: url(sansation_light.woff);
+                }
+            |]
+        it "cassius" $
+            celper "@font-face{font-family:myFirstFont;src:url(sansation_light.woff)}"
+            [cassiusOrd|
+                @font-face
+                    font-family: myFirstFont
+                    src: url(sansation_light.woff)
+            |]
+
+    describe "trailing semicolon in mixin" $ do
+        let someMixin = [luciusMixinOrd|foo:bar|]
+        it "direct in lucius" $
+            celper "baz{foo:bar}" [luciusOrd|
+                baz {
+                    ^{someMixin};
+                }
+            |]
+
+        it "implicit in cassius #194" $
+            celper "baz{foo:bar}" [cassiusOrd|
+                baz
+                    ^{someMixin}
+            |]
+
 data Url = Home | Sub SubUrl
 data SubUrl = SubUrl
 render :: Url -> [(Text, Text)] -> Text
@@ -622,12 +1191,49 @@ bin
         , "urlp:url(url?p=q)}"
         ]
 
+caseCassiusOrd :: Assertion
+caseCassiusOrd = do
+    let var = "var"
+    let urlp = (Home, [(pack "p", pack "q")])
+    flip celper [cassiusOrd|
+foo
+    background: #{colorBlack}
+    bar: baz
+    color: #{colorRed}
+bin
+        background-image: url(@{Home})
+        bar: bar
+        color: #{(((Color 127) 100) 5)}
+        f#{var}x: someval
+        unicode-test: שלום
+        urlp: url(@?{urlp})
+|] $ concat
+        [ "foo{background:#000;bar:baz;color:#F00}"
+        , "bin{"
+        , "background-image:url(url);"
+        , "bar:bar;color:#7F6405;fvarx:someval;unicode-test:שלום;"
+        , "urlp:url(url?p=q)}"
+        ]
+
 caseCassiusFile :: Assertion
 caseCassiusFile = do
     let var = "var"
     let selector = "foo"
     let urlp = (Home, [(pack "p", pack "q")])
     flip celper $(cassiusFile "test/cassiuses/external1.cassius") $ concat
+        [ "foo{background:#000;bar:baz;color:#F00}"
+        , "bin{"
+        , "background-image:url(url);"
+        , "bar:bar;color:#7F6405;fvarx:someval;unicode-test:שלום;"
+        , "urlp:url(url?p=q)}"
+        ]
+
+caseCassiusFileOrd :: Assertion
+caseCassiusFileOrd = do
+    let var = "var"
+    let selector = "foo"
+    let urlp = (Home, [(pack "p", pack "q")])
+    flip celper $(cassiusFileOrd "test/cassiuses/external1.cassius") $ concat
         [ "foo{background:#000;bar:baz;color:#F00}"
         , "bin{"
         , "background-image:url(url);"
@@ -643,9 +1249,29 @@ caseCassiusSingleComment =
         */
         |] ""
 
+caseCassiusSingleCommentOrd :: Assertion
+caseCassiusSingleCommentOrd =
+    flip celper [cassiusOrd|
+        /*
+        this is a comment
+        */
+        |] ""
+
 caseCassiusLeadingComment :: Assertion
 caseCassiusLeadingComment =
     flip celper [cassius|
+        /*
+        this is a comment
+        */
+        sel1
+            foo: bar
+        sel2
+            baz: bin
+        |] "sel1{foo:bar}sel2{baz:bin}"
+
+caseCassiusLeadingCommentOrd :: Assertion
+caseCassiusLeadingCommentOrd =
+    flip celper [cassiusOrd|
         /*
         this is a comment
         */
@@ -666,4 +1292,13 @@ caseLuciusFileDebug = do
     celper "foo {\n    var: 1;\n}\n" $(luciusFileDebug "test/cassiuses/external2.lucius")
     writeFile "test/cassiuses/external2.lucius" "foo{#{var}: 2}"
     celper "foo {\n    var: 2;\n}\n" $(luciusFileDebug "test/cassiuses/external2.lucius")
+    writeFile "test/cassiuses/external2.lucius" "foo{#{var}: 1}"
+
+caseLuciusFileDebugOrd :: Assertion
+caseLuciusFileDebugOrd = do
+    let var = "var"
+    writeFile "test/cassiuses/external2.lucius" "foo{#{var}: 1}"
+    celper "foo {\n    var: 1;\n}\n" $(luciusFileDebugOrd "test/cassiuses/external2.lucius")
+    writeFile "test/cassiuses/external2.lucius" "foo{#{var}: 2}"
+    celper "foo {\n    var: 2;\n}\n" $(luciusFileDebugOrd "test/cassiuses/external2.lucius")
     writeFile "test/cassiuses/external2.lucius" "foo{#{var}: 1}"


### PR DESCRIPTION
As noted in #262 , at the moment attribute order is not preserved when using mixins.

To solve the problem I changed the `Block` structure and also got rid of some Type Families. This made it possible to get rid of unnecessary fields and reduce problems when working with TH.
At the moment we can collect mixins differently with legacy parsers (in `blockUnresMixins   :: ![Deref]`) and new parsers (in `blockUnresAttrs    :: ![Either (Attr 'Unresolved) Deref]`). 
```haskell
data Block (a :: Resolved) where
  BlockResolved :: 
    { blockResSelector :: !Builder
    , blockResAttrs    :: ![Attr 'Resolved]
    } -> Block 'Resolved
  BlockUnresolved ::
    { blockUnresSelector :: ![Contents]
    , blockUnresAttrs    :: ![Either (Attr 'Unresolved) Deref]
    , blockUnresBlocks   :: ![(HasLeadingSpace, Block 'Unresolved)]
    , blockUnresMixins   :: ![Deref]
    } -> Block 'Unresolved
```

I left the work of existing `cassius` and `lucius` parsers unchanged, and introduced new parsers with the `...Ord` postfix. I do not know how successful this naming is.
