### PR TITLE
Support GHC 8.4 and update CI for newer versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         stack_args:
           - --resolver=nightly
-          - --resolver=lts-18
-          - --resolver=lts-22
+          - --resolver=lts-21
           - --resolver=lts-20
           - --resolver=lts-19
+          - --resolver=lts-18
           - --resolver=lts-16
           - --resolver=lts-14
           - --resolver=lts-12

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,12 @@ jobs:
         stack_args:
           - --resolver=nightly
           - --resolver=lts-18
+          - --resolver=lts-22
+          - --resolver=lts-20
+          - --resolver=lts-19
           - --resolver=lts-16
           - --resolver=lts-14
+          - --resolver=lts-12
           - --stack-yaml=stack-ghc-9.2.yaml
         exclude:
           - os: windows-latest

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -35,7 +35,7 @@ extra-source-files:
 
 library
     default-language: Haskell2010
-    build-depends:   base             >= 4.12    && < 5
+    build-depends:   base             >= 4.11    && < 5
                    , time             >= 1
                    , containers
                    , template-haskell >= 2.7


### PR DESCRIPTION
From https://github.com/yesodweb/persistent/pull/1499

This PR relaxes the `base` bound on Shakespare to allow GHC 8.4. Testing locally and it builds and tests fine.

I've updated the CI script to cover 8.4, and also newer GHC LTS versions.