### PR TITLE
Fix 100⨯ slowdown on parsec-3.1.15

### DIFF
--- a/Text/Hamlet/Parse.hs
+++ b/Text/Hamlet/Parse.hs
@@ -79,7 +79,7 @@ data Line = LineForall Deref Binding
 
 parseLines :: HamletSettings -> String -> Result (Maybe NewlineStyle, HamletSettings, [(Int, Line)])
 parseLines set s =
-    case parse parser s s of
+    case parse parser "[Hamlet input]" s of
         Left e -> Error $ show e
         Right x -> Ok x
   where


### PR DESCRIPTION
Passing *the entire input* as its name... isn't a bright idea — because the "name of input" gets included into error messages, and thus is threaded throughout parsing process.

parsec-3.1.15 has slightly changed the frequency with which SourceLoc's get compared — https://github.com/haskell/parsec/issues/171 

Combined, the two facts above lead to Hamlet parsing runtime blowing up 100⨯ on ~40kiB template — when compiled with parsec-3.1.15.0 (e.g. in Stackage LTS-20.26). Even simply 40kiB of comment-lines suffices.

The parsec aspect discussed at https://github.com/haskell/parsec/issues/171