### PR TITLE
Provide context parsing in the `mkMessage` function

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,34 +14,29 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        stack_args:
-          - --resolver=nightly
-          - --resolver=lts-21
-          - --resolver=lts-20
-          - --resolver=lts-19
-          - --resolver=lts-18
-          - --resolver=lts-16
-          - --resolver=lts-14
-          - --resolver=lts-12
-          - --stack-yaml=stack-ghc-9.2.yaml
-        exclude:
-          - os: windows-latest
-            stack_args: "--stack-yaml=stack-ghc-9.2.yaml"
+        args:
+        - "--resolver lts-22"
+        - "--resolver lts-21"
+        - "--resolver lts-20"
 
     steps:
       - name: Clone project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Install stack if needed
+        shell: bash
+        run: |
+            set -ex
+            if [[ "${{ matrix.os }}" == "macos-latest" ]]
+            then
+                # macos-latest does not include Haskell tools as of 2024-05-06.
+              curl -sSL https://get.haskellstack.org/ | sh
+            fi
 
       - name: Build and run tests
         shell: bash
         run: |
             set -ex
-            stack upgrade
             stack --version
-            if [[ "${{ runner.os }}" = 'Windows' ]]
-            then
-              # Looks like a bug in Stack, this shouldn't break things
-              ls C:/ProgramData/Chocolatey/bin/
-              rm C:/ProgramData/Chocolatey/bin/ghc*
-            fi
-            stack test --fast --no-terminal ${{ matrix.stack_args }}
+            stack test --fast --no-terminal ${{ matrix.args }}
+

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,5 @@
 # ChangeLog for shakespeare
 
-### 2.1.1
-
-* Add support for `TypeApplications` inside Shakespeare quasiquotes
-
 ### 2.1.0
 
 * Add `OverloadedRecordDot`-style record access in expressions

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -1,5 +1,5 @@
 name:            shakespeare
-version:         2.1.1
+version:         2.1.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -1,5 +1,5 @@
 name:            shakespeare
-version:         2.1.0
+version:         2.1.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -146,8 +146,7 @@ test-suite test
                  , blaze-markup
                  , blaze-html
                  , exceptions
-
-
+ 
 source-repository head
   type:     git
   location: https://github.com/yesodweb/shakespeare.git

--- a/test/Text/Shakespeare/BaseSpec.hs
+++ b/test/Text/Shakespeare/BaseSpec.hs
@@ -33,31 +33,6 @@ spec = do
             (DerefBranch (DerefIdent (Ident "+")) (DerefIdent (Ident "a")))
             (DerefIdent (Ident "b"))))
 
-  it "parseDeref parse single type applications" $ do
-    runParser parseDeref () "" "x @y" `shouldBe`
-      Right
-        (DerefBranch
-          (DerefIdent (Ident "x"))
-          (DerefType "y"))
-  it "parseDeref parse unit type applications" $ do
-    runParser parseDeref () "" "x @()" `shouldBe`
-      Right
-        (DerefBranch
-          (DerefIdent (Ident "x"))
-          (DerefType "()"))
-  it "parseDeref parse compound type applications" $ do
-    runParser parseDeref () "" "x @(Maybe String)" `shouldBe`
-      Right
-        (DerefBranch
-          (DerefIdent (Ident "x"))
-          (DerefType "Maybe String"))
-  it "parseDeref parse single @ as operator" $ do
-    runParser parseDeref () "" "x @ y" `shouldBe`
-      Right
-        (DerefBranch
-          (DerefBranch (DerefIdent (Ident "@")) (DerefIdent (Ident "x")))
-          (DerefIdent (Ident "y")))
-
   it "parseDeref parse expressions with record dot" $ do
     runParser parseDeref () "" "x.y" `shouldBe`
       Right (DerefGetField (DerefIdent (Ident "x")) "y")
@@ -131,3 +106,4 @@ spec = do
 
     eShowErrors :: Either ParseError c -> c
     eShowErrors = either (error . show) id
+

--- a/test/Text/Shakespeare/I18NSpec.hs
+++ b/test/Text/Shakespeare/I18NSpec.hs
@@ -1,16 +1,26 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeFamilies          #-}
+
 module Text.Shakespeare.I18NSpec
     ( spec
     ) where
 
 import           Data.Text             (Text)
 import           Text.Shakespeare.I18N
+import           Language.Haskell.TH.Syntax (Lift(..)) 
 
 spec :: Monad m => m ()
 spec = return ()
 
-data Test = Test
+class Lift master => YesodSubApp master where
+   data YesodSubAppData master :: *
 
-mkMessage "Test" "test-messages" "en"
+newtype SubApp master = SubApp
+  {
+     getOrdering :: Ordering
+  }
+
+mkMessage "(YesodSubApp master) => SubApp master" "test-messages" "en" 
+


### PR DESCRIPTION
Provided context parsing in the mkMessage function. Resolves [issue  #282: mkMessage should support context parsing](https://github.com/yesodweb/shakespeare/issues/282)

CI passed successfully. See the link below:
[https://github.com/Oleksandr-Zhabenko/shakespeare/actions/runs/10403325875](https://github.com/Oleksandr-Zhabenko/shakespeare/actions/runs/10403325875)