### PR TITLE
shakespeare.cabal: include hspec-discover as build tool

### DIFF
--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -128,6 +128,7 @@ test-suite test
     type: exitcode-stdio-1.0
 
     ghc-options:   -Wall
+    build-tool-depends: hspec-discover:hspec-discover
     build-depends: base             >= 4.9     && < 5
                  , shakespeare
                  , time             >= 1


### PR DESCRIPTION
It is technically required to run the tests.