### PR TITLE
Multi param mk message

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for shakespeare
 
+### 2.1.5
+
+* Add better support for `mkMessage`ing data types with params.[#295](https://github.com/yesodweb/shakespeare/pull/295)
+
+
 ### 2.1.4
 
 * [#292](https://github.com/yesodweb/shakespeare/pull/292)

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -1,5 +1,5 @@
 name:            shakespeare
-version:         2.1.4
+version:         2.1.5
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/test/Text/Shakespeare/I18NSpec.hs
+++ b/test/Text/Shakespeare/I18NSpec.hs
@@ -20,7 +20,7 @@ newtype SubApp master = SubApp
      getOrdering :: Ordering
   }
 
-data Test = Test
+data Test a b = Test
 
 class Testable a where
   isTestable :: a -> Bool 
@@ -33,5 +33,5 @@ spec = return ()
 
 mkMessage "(YesodSubApp master) => SubApp master" "other-messages" "en" 
 
-mkMessage "Test" "test-messages" "en"
+mkMessage "Test a b" "test-messages" "en"
 

--- a/test/Text/Shakespeare/I18NSpec.hs
+++ b/test/Text/Shakespeare/I18NSpec.hs
@@ -10,23 +10,12 @@ module Text.Shakespeare.I18NSpec
 import           Data.Text             (Text)
 import           Text.Shakespeare.I18N
 import           Language.Haskell.TH.Syntax
-import           Test.Hspec
 
 class Lift master => YesodSubApp master where
-   data YesodSubAppData master :: *
 
-newtype SubApp master = SubApp
-  {
-     getOrdering :: Ordering
-  }
+data SubApp master
 
-data Test a b = Test
-
-class Testable a where
-  isTestable :: a -> Bool 
-
-instance Testable Test where 
-  isTestable Test = True
+data Test a b
 
 spec :: Monad m => m ()
 spec = return ()
@@ -34,4 +23,3 @@ spec = return ()
 mkMessage "(YesodSubApp master) => SubApp master" "other-messages" "en" 
 
 mkMessage "Test a b" "test-messages" "en"
-


### PR DESCRIPTION
`mkMessage "Test a b" ...` will produce `Test ab` at some point, which is obviously incorrect. This PR fixes that so that you can have multi parameter message making.