### PR TITLE
Revert "Add option for site variable in `mkMessage`'s generated messages"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,5 @@
 # ChangeLog for shakespeare
 
-### 2.1.7
-
-* Let users name and use the site parameter for renderMessage so site config can influence the messages [#296](https://github.com/yesodweb/shakespeare/pull/296)
-
 ### 2.1.6
 
 * Introduce options type for i18n, add ability to stop using record types for messages [#290](https://github.com/yesodweb/shakespeare/pull/290)

--- a/other-messages/en.msg
+++ b/other-messages/en.msg
@@ -27,4 +27,3 @@ PleaseCorrectCommentRR: Your submitted comment had some errors, please correct a
 HomepageTitleRR: Yesod Blog Demo
 BlogArchiveTitleRR: Blog Archive
 
-SiteMessageRR: The site has a message for you: #{getGreeting _site}

--- a/shakespeare.cabal
+++ b/shakespeare.cabal
@@ -1,5 +1,5 @@
 name:            shakespeare
-version:         2.1.7
+version:         2.1.6
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/test/Text/Shakespeare/I18NSpec.hs
+++ b/test/Text/Shakespeare/I18NSpec.hs
@@ -11,37 +11,28 @@ import           Data.Text             (Text)
 import           Text.Shakespeare.I18N
 import           Test.Hspec
 
-class YesodSubApp sub where
-  getGreeting :: sub -> Text
+class YesodSubApp master where
 
-instance YesodSubApp () where
-  getGreeting _ = "unit"
+instance YesodSubApp ()
 
-data SubApp master = SubApp master Text
+newtype SubApp master = SubApp master
 
-instance YesodSubApp (SubApp master) where
-  getGreeting (SubApp _ s) = s
+instance YesodSubApp (SubApp master)
 
 data Test a b
 
-mkMessageOpts
-  (setSiteParameterName (Just "_site") defMakeMessageOpts)
-  "(YesodSubApp master) => SubApp master"
-  "(YesodSubApp master) => SubApp master"
-  "other-messages"
-  "en"
+mkMessage "(YesodSubApp master) => SubApp master" "other-messages" "en" 
 
 mkMessage "Test a b" "test-messages" "en"
 
 newtype SubAppNoRec master = SubAppNoRec master
 
-instance YesodSubApp (SubAppNoRec master) where
-  getGreeting _ = "no greeting"
+instance YesodSubApp (SubAppNoRec master)
 
 data TestNoRec
 
 mkMessageOpts
-  (setSiteParameterName (Just "_site") $ setConPrefix "MsgNR" $ setUseRecordCons False defMakeMessageOpts)
+  (setConPrefix "MsgNR" $ setUseRecordCons False defMakeMessageOpts)
   "(YesodSubApp master) => SubAppNoRec master"
   "(YesodSubApp master) => SubAppNoRec master"
   "other-messages"
@@ -59,11 +50,8 @@ spec = do
   describe "I18N" $ do
     it "should generate messages with record constructors" $ do
       let msg = MsgEntryCreatedRR { subAppMessageTitle = "foo" }
-      renderMessage (SubApp () "") [] msg `shouldBe` "Your new blog post, foo, has been created"
+      renderMessage (SubApp ()) [] msg `shouldBe` "Your new blog post, foo, has been created"
 
     it "should generate messages without record constructors" $ do
       let msg = MsgNREntryCreatedRR "bar"
       renderMessage (SubAppNoRec ()) [] msg `shouldBe` "Your new blog post, bar, has been created"
-
-    it "should generate messages based off of site data" $ do
-      renderMessage (SubApp () "Hi there!") [] MsgSiteMessageRR `shouldBe` "The site has a message for you: Hi there!"


### PR DESCRIPTION
This reverts commit bec6151a3b7ddf3953b82a4f9a349cbe97b09546.

This is a misfeature added to allow messages to depend on site data, but negates the ability of the messages feature to do I18n. For example, if you had a subsite and two instances of that subsite, you may want different names for whatever the parent site is. This feature was intended to allow you to sub in the name of the parent site. However, the subbed in word would not be correctly internationalised, and thus this breaks a fundamental feature of messages.

The correct way to do the above is to create multiple messages sets with different parent site names, and their own sets of language files.

@jezen 